### PR TITLE
Migrate to coinbase part 1

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-set -ex
-
-docker build . -t bazelruby/ruby-2.6.5
-docker push       bazelruby/ruby-2.6.5
-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     working_directory: /home/circleci/repo
     resource_class: medium
     docker:
-      - image: bazelruby/ruby-2.6.5
+      - image: circleci/ruby:2.6.5
     environment:
       PATH: "/usr/local/bin:/usr/bin:/sbin:/opt/bin:/home/circleci/repo/bin:/bin:/sbin:/usr/sbin"
       BUNDLE_PATH: /home/circleci/.bundle_cache

--- a/README.md
+++ b/README.md
@@ -26,10 +26,7 @@
 
 | Build | Status |
 |---------:	|---------------------------------------------------------------------------------------------------------------------------------------------------	|
-| CircleCI Develop: 	| [![CircleCI](https://circleci.com/gh/bazelruby/rules_ruby/tree/develop.svg?style=svg)](https://circleci.com/gh/bazelruby/rules_ruby/tree/develop) 	|
-| CircleCI Default: 	| [![CircleCI](https://circleci.com/gh/bazelruby/rules_ruby.svg?style=svg)](https://circleci.com/gh/bazelruby/rules_ruby) 	|
-| Develop: 	| [![Build Status](https://travis-ci.org/bazelruby/rules_ruby.svg?branch=develop)](https://travis-ci.org/bazelruby/rules_ruby) 	|
-| Master: 	| [![Build Status](https://travis-ci.org/bazelruby/rules_ruby.svg?branch=master)](https://travis-ci.org/bazelruby/rules_ruby) 	|
+| CircleCI Master: 	| [![CircleCI](https://circleci.com/gh/coinbase/rules_ruby.svg?style=svg)](https://circleci.com/gh/coinbase/rules_ruby) 	|
 
 
 # Rules Ruby
@@ -38,30 +35,30 @@ Ruby rules for [Bazel](https://bazel.build).
 
 ** Current Status:** *Work in progress.*
 
-Note: we have a short guide on [Building your first Ruby Project](https://github.com/bazelruby/rules_ruby/wiki/Build-your-ruby-project) on the Wiki. We encourage you to check it out.
+Note: we have a short guide on [Building your first Ruby Project](https://github.com/coinbase/rules_ruby/wiki/Build-your-ruby-project) on the Wiki. We encourage you to check it out.
 
 ## Usage
 
 ### `WORKSPACE` File
 
-Add `ruby_rules_dependencies` and `ruby_register_toolchains` into your `WORKSPACE` file.
+Add `rules_ruby_dependencies` and `ruby_register_toolchains` into your `WORKSPACE` file.
 
 ```python
 # To get the latest, grab the 'develop' branch.
 
 git_repository(
-    name = "bazelruby_ruby_rules",
-    remote = "https://github.com/bazelruby/rules_ruby.git",
+    name = "coinbase_rules_ruby",
+    remote = "https://github.com/coinbase/rules_ruby.git",
     branch = "develop",
 )
 
 load(
-    "@bazelruby_ruby_rules//ruby:deps.bzl",
+    "@coinbase_rules_ruby//ruby:deps.bzl",
     "ruby_register_toolchains",
-    "ruby_rules_dependencies",
+    "rules_ruby_dependencies",
 )
 
-ruby_rules_dependencies()
+rules_ruby_dependencies()
 
 ruby_register_toolchains()
 ```
@@ -97,7 +94,7 @@ Add `ruby_library`, `ruby_binary` or `ruby_test` into your `BUILD.bazel` files.
 
 ```python
 load(
-    "@bazelruby_ruby_rules//ruby:defs.bzl",
+    "@coinbase_rules_ruby//ruby:defs.bzl",
     "ruby_binary",
     "ruby_library",
     "ruby_test",
@@ -140,7 +137,7 @@ ruby_rspec(
 
 The following diagram attempts to capture the implementation behind `ruby_library` that depends on the result of `bundle install`, and a `ruby_binary` that depends on both:
 
-![Ruby Rules](docs/img/ruby_rules.png)
+![Ruby Rules](docs/img/rules_ruby.png)
 
 
 ### `ruby_library`
@@ -388,22 +385,22 @@ Example: `WORKSPACE`:
 
 ```python
 git_repository(
-    name = "bazelruby_ruby_rules",
-    remote = "https://github.com/bazelruby/rules_ruby.git",
+    name = "coinbase_rules_ruby",
+    remote = "https://github.com/coinbase/rules_ruby.git",
     tag = "v0.1.0",
 )
 
 load(
-    "@bazelruby_ruby_rules//ruby:deps.bzl",
+    "@coinbase_rules_ruby//ruby:deps.bzl",
     "ruby_register_toolchains",
-    "ruby_rules_dependencies",
+    "rules_ruby_dependencies",
 )
 
-ruby_rules_dependencies()
+rules_ruby_dependencies()
 
 ruby_register_toolchains()
 
-load("@bazelruby_ruby_rules//ruby:defs.bzl", "ruby_bundle")
+load("@coinbase_rules_ruby//ruby:defs.bzl", "ruby_bundle")
 
 ruby_bundle(
     name = "gems",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,8 +1,8 @@
-workspace(name = "bazelruby_ruby_rules")
+workspace(name = "coinbase_rules_ruby")
 
-load("@//ruby:deps.bzl", "ruby_rules_dependencies")
+load("@//ruby:deps.bzl", "rules_ruby_dependencies")
 
-ruby_rules_dependencies()
+rules_ruby_dependencies()
 
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
@@ -17,7 +17,7 @@ load("@//ruby:deps.bzl", "ruby_register_toolchains")
 ruby_register_toolchains()
 
 local_repository(
-    name = "bazelruby_ruby_rules_ruby_tests_testdata_another_workspace",
+    name = "coinbase_rules_ruby_ruby_tests_testdata_another_workspace",
     path = "ruby/tests/testdata/another_workspace",
 )
 
@@ -93,7 +93,7 @@ container_pull(
     repository = "library/ruby",
 )
 
-load("@bazelruby_ruby_rules//ruby:defs.bzl", "bundle_install")
+load("@coinbase_rules_ruby//ruby:defs.bzl", "bundle_install")
 
 bundle_install(
     name = "bundle",

--- a/bin/test-suite
+++ b/bin/test-suite
@@ -128,14 +128,6 @@ $(help-example bin/test-suite simple-example)
   exit 0
 }
 
-# Runs Rubocop Tests
-test::rubocop() {
-  __test::exec rubocop "
-    bundle install --path=${BUNDLE_PATH}
-    bundle exec rubocop -E -D .rubocop.yml --force-exclusion
-  "
-}
-
 # Builds and runs workspace inside examples/simple_script
 test::simple-script() {
   __test::exec simple-script "
@@ -173,7 +165,6 @@ test::all() {
   test::bazel-info
   test::workspace
   test::simple-script
-  test::rubocop
   test::rspec
 }
 

--- a/bin/test-suite
+++ b/bin/test-suite
@@ -136,13 +136,6 @@ test::rubocop() {
   "
 }
 
-# Runs Buildifier
-test::buildifier() {
-  __test::exec buildifier "
-    bazel run :buildifier-check
-  "
-}
-
 # Builds and runs workspace inside examples/simple_script
 test::simple-script() {
   __test::exec simple-script "
@@ -180,7 +173,6 @@ test::all() {
   test::bazel-info
   test::workspace
   test::simple-script
-  test::buildifier
   test::rubocop
   test::rspec
 }

--- a/examples/simple_rails_api/BUILD
+++ b/examples/simple_rails_api/BUILD
@@ -1,7 +1,7 @@
 package(default_visibility = ["//:__subpackages__"])
 
 load(
-    "@bazelruby_ruby_rules//ruby:defs.bzl",
+    "@coinbase_rules_ruby//ruby:defs.bzl",
     "ruby_binary",
     "ruby_test",
 )

--- a/examples/simple_rails_api/WORKSPACE
+++ b/examples/simple_rails_api/WORKSPACE
@@ -1,19 +1,19 @@
-workspace(name = "bazelruby_ruby_rules_example")
+workspace(name = "coinbase_rules_ruby_example")
 
 # Importing rules_ruby from the parent directory for developing
 # rules_ruby itself...
 local_repository(
-    name = "bazelruby_ruby_rules",
+    name = "coinbase_rules_ruby",
     path = "../..",
 )
 
 load(
-    "@bazelruby_ruby_rules//ruby:deps.bzl",
+    "@coinbase_rules_ruby//ruby:deps.bzl",
     "ruby_register_toolchains",
-    "ruby_rules_dependencies",
+    "rules_ruby_dependencies",
 )
 
-ruby_rules_dependencies()
+rules_ruby_dependencies()
 
 ruby_register_toolchains(version = "2.6.5")
 
@@ -21,7 +21,7 @@ load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
 bazel_skylib_workspace()
 
-load("@bazelruby_ruby_rules//ruby:defs.bzl", "bundle_install")
+load("@coinbase_rules_ruby//ruby:defs.bzl", "bundle_install")
 
 bundle_install(
     name = "bundle",

--- a/examples/simple_script/BUILD.bazel
+++ b/examples/simple_script/BUILD.bazel
@@ -1,7 +1,7 @@
 package(default_visibility = ["//:__subpackages__"])
 
 load(
-    "@bazelruby_ruby_rules//ruby:defs.bzl",
+    "@coinbase_rules_ruby//ruby:defs.bzl",
     "ruby_binary",
     "ruby_library",
     "ruby_rspec",

--- a/examples/simple_script/WORKSPACE
+++ b/examples/simple_script/WORKSPACE
@@ -1,23 +1,23 @@
-workspace(name = "bazelruby_ruby_rules_example")
+workspace(name = "coinbase_rules_ruby_example")
 
 # Importing rules_ruby from the parent directory for developing
 # rules_ruby itself...
 local_repository(
-    name = "bazelruby_ruby_rules",
+    name = "coinbase_rules_ruby",
     path = "../..",
 )
 
 load(
-    "@bazelruby_ruby_rules//ruby:deps.bzl",
+    "@coinbase_rules_ruby//ruby:deps.bzl",
     "ruby_register_toolchains",
-    "ruby_rules_dependencies",
+    "rules_ruby_dependencies",
 )
 
-ruby_rules_dependencies()
+rules_ruby_dependencies()
 
 ruby_register_toolchains(version = "2.6.5")
 
-load("@bazelruby_ruby_rules//ruby:defs.bzl", "ruby_bundle")
+load("@coinbase_rules_ruby//ruby:defs.bzl", "ruby_bundle")
 
 ruby_bundle(
     name = "bundle",

--- a/examples/simple_script/lib/BUILD
+++ b/examples/simple_script/lib/BUILD
@@ -1,7 +1,7 @@
 package(default_visibility = ["//:__subpackages__"])
 
 load(
-    "@bazelruby_ruby_rules//ruby:defs.bzl",
+    "@coinbase_rules_ruby//ruby:defs.bzl",
     "ruby_library",
 )
 

--- a/ruby/defs.bzl
+++ b/ruby/defs.bzl
@@ -1,22 +1,22 @@
 load(
-    "@bazelruby_ruby_rules//ruby/private:toolchain.bzl",
+    "@coinbase_rules_ruby//ruby/private:toolchain.bzl",
     _toolchain = "ruby_toolchain",
 )
 load(
-    "@bazelruby_ruby_rules//ruby/private:library.bzl",
+    "@coinbase_rules_ruby//ruby/private:library.bzl",
     _library = "ruby_library",
 )
 load(
-    "@bazelruby_ruby_rules//ruby/private:binary.bzl",
+    "@coinbase_rules_ruby//ruby/private:binary.bzl",
     _binary = "ruby_binary",
     _test = "ruby_test",
 )
 load(
-    "@bazelruby_ruby_rules//ruby/private:bundle.bzl",
+    "@coinbase_rules_ruby//ruby/private:bundle.bzl",
     _ruby_bundle = "ruby_bundle",
 )
 load(
-    "@bazelruby_ruby_rules//ruby/private:rspec.bzl",
+    "@coinbase_rules_ruby//ruby/private:rspec.bzl",
     _ruby_rspec = "ruby_rspec",
     _ruby_rspec_test = "ruby_rspec_test",
 )

--- a/ruby/deps.bzl
+++ b/ruby/deps.bzl
@@ -1,13 +1,13 @@
 # Repository rules
 load(
-    "@bazelruby_ruby_rules//ruby/private:dependencies.bzl",
-    _ruby_rules_dependencies = "ruby_rules_dependencies",
+    "@coinbase_rules_ruby//ruby/private:dependencies.bzl",
+    _rules_ruby_dependencies = "rules_ruby_dependencies",
 )
 load(
-    "@bazelruby_ruby_rules//ruby/private:sdk.bzl",
+    "@coinbase_rules_ruby//ruby/private:sdk.bzl",
     _register_toolchains = "ruby_register_toolchains",
 )
 
-ruby_rules_dependencies = _ruby_rules_dependencies
+rules_ruby_dependencies = _rules_ruby_dependencies
 
 ruby_register_toolchains = _register_toolchains

--- a/ruby/private/constants.bzl
+++ b/ruby/private/constants.bzl
@@ -1,6 +1,6 @@
 load(":providers.bzl", "RubyLibrary")
 
-RULES_RUBY_WORKSPACE_NAME = "@bazelruby_ruby_rules"
+RULES_RUBY_WORKSPACE_NAME = "@coinbase_rules_ruby"
 TOOLCHAIN_TYPE_NAME = "%s//ruby:toolchain_type" % RULES_RUBY_WORKSPACE_NAME
 
 DEFAULT_BUNDLER_VERSION = "2.1.2"

--- a/ruby/private/dependencies.bzl
+++ b/ruby/private/dependencies.bzl
@@ -1,6 +1,6 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-def ruby_rules_dependencies():
+def rules_ruby_dependencies():
     if "bazel_skylib" not in native.existing_rules():
         http_archive(
             name = "bazel_skylib",

--- a/ruby/private/sdk.bzl
+++ b/ruby/private/sdk.bzl
@@ -1,5 +1,5 @@
 load(
-    "@bazelruby_ruby_rules//ruby/private/toolchains:ruby_runtime.bzl",
+    "@coinbase_rules_ruby//ruby/private/toolchains:ruby_runtime.bzl",
     _ruby_runtime = "ruby_runtime",
 )
 

--- a/ruby/tests/BUILD.bazel
+++ b/ruby/tests/BUILD.bazel
@@ -120,7 +120,7 @@ ruby_binary(
     main = "load_path_in_runfiles_test.rb",
     deps = [
         "//ruby/tests/testdata:g",
-        "@bazelruby_ruby_rules_ruby_tests_testdata_another_workspace//baz/qux:j",
+        "@coinbase_rules_ruby_ruby_tests_testdata_another_workspace//baz/qux:j",
     ],
 )
 
@@ -137,7 +137,7 @@ ruby_test(
     main = "load_path_in_runfiles_test.rb",
     deps = [
         "//ruby/tests/testdata:g",
-        "@bazelruby_ruby_rules_ruby_tests_testdata_another_workspace//baz/qux:j",
+        "@coinbase_rules_ruby_ruby_tests_testdata_another_workspace//baz/qux:j",
     ],
 )
 
@@ -250,13 +250,13 @@ pkg_tar(
     include_runfiles = True,
     package_dir = "/app",
     remap_paths = {
-        "ruby": "load_path_in_runfiles.runfiles/bazelruby_ruby_rules/ruby",
+        "ruby": "load_path_in_runfiles.runfiles/coinbase_rules_ruby/ruby",
         ".": "load_path_in_runfiles.runfiles/",
     },
     strip_prefix = "dummy",
     symlinks = {
-        "/app/load_path_in_runfiles.runfiles/bazelruby_ruby_rules/external": "/app/load_path_in_runfiles.runfiles",
-        "/app/load_path_in_runfiles": "/app/load_path_in_runfiles.runfiles/bazelruby_ruby_rules/ruby/tests/load_path_in_runfiles",
+        "/app/load_path_in_runfiles.runfiles/coinbase_rules_ruby/external": "/app/load_path_in_runfiles.runfiles",
+        "/app/load_path_in_runfiles": "/app/load_path_in_runfiles.runfiles/coinbase_rules_ruby/ruby/tests/load_path_in_runfiles",
     },
 )
 

--- a/ruby/tests/load_path_in_runfiles_test.rb
+++ b/ruby/tests/load_path_in_runfiles_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 require 'ruby/tests/testdata/foo/g'
-require 'external/bazelruby_ruby_rules_ruby_tests_testdata_another_workspace/baz/qux/j'
+require 'external/coinbase_rules_ruby_ruby_tests_testdata_another_workspace/baz/qux/j'
 
 [g, j]

--- a/ruby/tests/testdata/another_workspace/WORKSPACE
+++ b/ruby/tests/testdata/another_workspace/WORKSPACE
@@ -1,5 +1,5 @@
-workspace(name = "bazelruby_ruby_rules_ruby_tests_testdata_another_workspace")
+workspace(name = "coinbase_rules_ruby_ruby_tests_testdata_another_workspace")
 
-load("@bazelruby_ruby_rules//ruby:defs.bzl", "ruby_register_toolchains")
+load("@coinbase_rules_ruby//ruby:defs.bzl", "ruby_register_toolchains")
 
 ruby_register_toolchains()

--- a/ruby/tests/testdata/another_workspace/baz/qux/BUILD.bazel
+++ b/ruby/tests/testdata/another_workspace/baz/qux/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@bazelruby_ruby_rules//ruby:defs.bzl", "ruby_library")
+load("@coinbase_rules_ruby//ruby:defs.bzl", "ruby_library")
 
 ruby_library(
     name = "j",


### PR DESCRIPTION
bazelruby -> coinbase
ruby_rules -> rules_ruby

Remove rubocop and buildifier from test-suite since they have their own circle jobs
Replace bazelruby ruby image with circleci ruby image.