### PR TITLE
Set GEM_PATH and include gemspec files in runfiles

### DIFF
--- a/ruby/private/binary.bzl
+++ b/ruby/private/binary.bzl
@@ -10,6 +10,17 @@ def _to_manifest_path(ctx, file):
     else:
         return ("%s/%s" % (ctx.workspace_name, file.short_path))
 
+def _get_gem_path(incpaths):
+    """
+    incpaths is a list of `<bundle_name>/lib/ruby/<version>/gems/<gemname>-<gemversion>/lib`
+    The gem_path is `<bundle_name>/lib/ruby/<version>` so we can go from an incpath to the
+    gem_path pretty easily without much additional work.
+    """
+    if len(incpaths) == 0:
+        return ""
+    incpath = incpaths[0]
+    return incpath.rsplit("/", 3)[0]
+
 # Having this function allows us to override otherwise frozen attributes
 # such as main, srcs and deps. We use this in rb_rspec_test rule by
 # adding rspec as a main, and sources, and rspec gem as a dependency.
@@ -41,6 +52,8 @@ def rb_binary_macro(ctx, main, srcs):
         extra_deps = ctx.attr._misc_deps,
     )
 
+    gem_path = _get_gem_path(deps.incpaths.to_list())
+
     rubyopt = reversed(deps.rubyopt.to_list())
 
     ctx.actions.expand_template(
@@ -51,6 +64,7 @@ def rb_binary_macro(ctx, main, srcs):
             "{rubyopt}": repr(rubyopt),
             "{main}": repr(_to_manifest_path(ctx, main)),
             "{interpreter}": _to_manifest_path(ctx, interpreter),
+            "{gem_path}": gem_path,
         },
     )
 

--- a/ruby/private/binary_wrapper.tpl
+++ b/ruby/private/binary_wrapper.tpl
@@ -103,6 +103,8 @@ def main(args)
   runfiles_envkey, runfiles_envvalue = runfiles_envvar(runfiles)
   ENV[runfiles_envkey] = runfiles_envvalue if runfiles_envkey
 
+  ENV["GEM_PATH"] = File.join(runfiles, "{gem_path}") if "{gem_path}"
+
   ruby_program = find_rb_binary
 
   main = {main}

--- a/ruby/private/bundle/create_bundle_build_file.rb
+++ b/ruby/private/bundle/create_bundle_build_file.rb
@@ -33,7 +33,7 @@ GEM_TEMPLATE = <<~GEM_TEMPLATE
     name = "{name}",
     srcs = glob(
       include = [
-        "lib/ruby/{ruby_version}/gems/{name}-{version}/**/*",
+        "lib/ruby/{ruby_version}/gems/{name}-{version}/**",
         "lib/ruby/{ruby_version}/specifications/{name}-{version}.gemspec",
         "bin/*"
       ],

--- a/ruby/private/bundle/create_bundle_build_file.rb
+++ b/ruby/private/bundle/create_bundle_build_file.rb
@@ -34,6 +34,7 @@ GEM_TEMPLATE = <<~GEM_TEMPLATE
     srcs = glob(
       include = [
         "lib/ruby/{ruby_version}/gems/{name}-{version}/**/*",
+        "lib/ruby/{ruby_version}/specifications/{name}-{version}.gemspec",
         "bin/*"
       ],
       exclude = {exclude},

--- a/ruby/private/sdk.bzl
+++ b/ruby/private/sdk.bzl
@@ -6,7 +6,7 @@ load(
 def ruby_register_toolchains(version = "host"):
     """Registers ruby toolchains in the WORKSPACE file."""
 
-    supported_versions = ["host", "2.6.3", "2.6.5"]
+    supported_versions = ["host", "2.6.3", "2.6.5", "2.5.5"]
     if version in supported_versions:
         _ruby_runtime(
             name = "org_ruby_lang_ruby_toolchain",


### PR DESCRIPTION
Running the simple_rails_api I found that the API would start up correctly, but curling localhost:3000 was causing errors that looked like:
`ERROR LoadError: Error loading the 'sqlite3' Active Record adapter. Missing a gem it depends on? Could not find 'sqlite3' (~> 1.4) among 62 total gem(s)\nChecked in 'GEM_PATH=~/.gem/ruby/2.6.0:~/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0', execute 'gem env' for more information`

Neither of the two GEM_PATH folders it references are the folder that bazel is installing its gems into. So, obviously the bazel gem folder needs to be added to the GEM_PATH for this to be able to look up some gems correctly.

I ran `GEM_PATH=<bazel_runfiles_gem_folder> gem list` and found it was listing system gems instead of recognizing that folder as containing gems. However, running `GEM_PATH=<bazel_external_gem_folder> gem list` listed the gems installed by bazel.

Working from there it looks like the specifications folder that contains gemspecs is also needed for gem list to work. Adding those files to the generated ruby_library caused the runfiles gem list to work correctly. At that point setting the GEM_PATH in the binary_wrapper.tpl fixed the simple_rails_api and curl started working.

Not 100% sure that this is the best way to look up the gem_path, but it will unblock us for now. Thoughts?