### PR TITLE
Add force_gem_pristine attr to rb_binary

### DIFF
--- a/ruby/private/binary.bzl
+++ b/ruby/private/binary.bzl
@@ -88,12 +88,7 @@ def rb_binary_impl(ctx):
 
 rb_binary = rule(
     implementation = rb_binary_impl,
-    attrs = dict(
-        RUBY_ATTRS,
-        force_gem_pristine = attr.string_list(
-            doc = "Jank hack. Run gem pristine on some gems that don't handle symlinks well",
-        )
-    ),
+    attrs = RUBY_ATTRS,
     executable = True,
     toolchains = [TOOLCHAIN_TYPE_NAME],
 )

--- a/ruby/private/binary.bzl
+++ b/ruby/private/binary.bzl
@@ -54,6 +54,8 @@ def rb_binary_macro(ctx, main, srcs):
 
     gem_path = _get_gem_path(deps.incpaths.to_list())
 
+    gems_to_pristine = ctx.attr.force_gem_pristine
+
     rubyopt = reversed(deps.rubyopt.to_list())
 
     ctx.actions.expand_template(
@@ -65,6 +67,8 @@ def rb_binary_macro(ctx, main, srcs):
             "{main}": repr(_to_manifest_path(ctx, main)),
             "{interpreter}": _to_manifest_path(ctx, interpreter),
             "{gem_path}": gem_path,
+            "{should_gem_pristine}": str(len(gems_to_pristine) > 0).lower(),
+            "{gems_to_pristine}": " ".join(gems_to_pristine),
         },
     )
 
@@ -84,7 +88,12 @@ def rb_binary_impl(ctx):
 
 rb_binary = rule(
     implementation = rb_binary_impl,
-    attrs = RUBY_ATTRS,
+    attrs = dict(
+        RUBY_ATTRS,
+        force_gem_pristine = attr.string_list(
+            doc = "Jank hack. Run gem pristine on some gems that don't handle symlinks well",
+        )
+    ),
     executable = True,
     toolchains = [TOOLCHAIN_TYPE_NAME],
 )

--- a/ruby/private/binary_wrapper.tpl
+++ b/ruby/private/binary_wrapper.tpl
@@ -91,6 +91,13 @@ def find_rb_binary
   )
 end
 
+def find_gem_binary
+  File.join(
+    RbConfig::CONFIG['bindir'],
+    'gem',
+  )
+end
+
 def main(args)
   custom_loadpaths = {loadpaths}
   runfiles = find_runfiles
@@ -104,6 +111,7 @@ def main(args)
   ENV[runfiles_envkey] = runfiles_envvalue if runfiles_envkey
 
   ENV["GEM_PATH"] = File.join(runfiles, "{gem_path}") if "{gem_path}"
+  ENV["GEM_HOME"] = File.join(runfiles, "{gem_path}") if "{gem_path}"
 
   ruby_program = find_rb_binary
 
@@ -119,6 +127,17 @@ def main(args)
       end
     end
   end
+
+  # This is a jank hack because some of our gems are having issues with how
+  # they are being installed. Most gems are fine, but this fixes the ones that
+  # aren't. Put it here instead of in the library because we want to fix the
+  # underlying issue and then tear this out.
+  if {should_gem_pristine} then
+    gem_program = find_gem_binary
+    puts "Running pristine on {gems_to_pristine}"
+    system(gem_program + " pristine {gems_to_pristine}")
+  end
+
   exec(ruby_program, *rubyopt, main, *args)
   # TODO(yugui) Support windows
 end

--- a/ruby/private/bundle/create_bundle_build_file.rb
+++ b/ruby/private/bundle/create_bundle_build_file.rb
@@ -35,6 +35,7 @@ GEM_TEMPLATE = <<~GEM_TEMPLATE
       include = [
         "lib/ruby/{ruby_version}/gems/{name}-{version}*/**",
         "lib/ruby/{ruby_version}/specifications/{name}-{version}*.gemspec",
+        "lib/ruby/{ruby_version}/cache/{name}-{version}*.gem",
         "bin/*"
       ],
       exclude = {exclude},

--- a/ruby/private/constants.bzl
+++ b/ruby/private/constants.bzl
@@ -22,6 +22,9 @@ RUBY_ATTRS = {
     "main": attr.label(
         allow_single_file = True,
     ),
+    "force_gem_pristine": attr.string_list(
+        doc = "Jank hack. Run gem pristine on some gems that don't handle symlinks well",
+    ),
     "_wrapper_template": attr.label(
         allow_single_file = True,
         default = "binary_wrapper.tpl",


### PR DESCRIPTION
Adds a force_gem_pristine attr to the rb_binary rule. 
Some ruby gems don't work well with the way they are being installed via bazel and it's causing them to be unusable. Running gem pristine on those gems puts them in a state where they start working again. My current hypothesis is that this has something to do with runfiles being symlinks because running gem pristine makes the files not symlinks.
This was added to the rb_binary rule instead of to the rb_library rule because we want to tear this out once we have time to figure out what is wrong with the underlying gem install behaviour.
 It's unclear how much this will cause non-hermetic behaviour, but right now I'll take working over perfect.