### PR TITLE
[bug] Fixes some broken properties of the current gem that is generated by rb_gem

### DIFF
--- a/ruby/private/gem.bzl
+++ b/ruby/private/gem.bzl
@@ -3,12 +3,11 @@ load(
     _rb_gemspec = "rb_gemspec",
 )
 load(
-    "@rules_pkg//:pkg.bzl",
-    "pkg_zip",
+    "//ruby/private/gem:gem.bzl",
+    _rb_build_gem = "rb_build_gem",
 )
 
 def rb_gem(name, version, gem_name, srcs = [], **kwargs):
-    _zip_name = "%s-%s" % (gem_name, version)
     _gemspec_name = name + "_gemspec"
 
     _rb_gemspec(
@@ -18,14 +17,11 @@ def rb_gem(name, version, gem_name, srcs = [], **kwargs):
         **kwargs
     )
 
-    pkg_zip(
-        name = _zip_name,
-        srcs = srcs + [":" + _gemspec_name],
-        strip_prefix = "./",
-    )
-
-    native.alias(
+    _rb_build_gem(
         name = name,
-        actual = ":" + _zip_name,
+        gem_name = gem_name,
+        gemspec = _gemspec_name,
+        version = version,
+        deps = srcs + [_gemspec_name],
         visibility = ["//visibility:public"],
     )

--- a/ruby/private/gem/BUILD.bazel
+++ b/ruby/private/gem/BUILD.bazel
@@ -1,0 +1,8 @@
+package(default_visibility = ["//ruby/private:__pkg__"])
+
+exports_files(
+    [
+        "gem_runner.rb",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/ruby/private/gem/gem.bzl
+++ b/ruby/private/gem/gem.bzl
@@ -15,8 +15,6 @@ def _rb_build_gem_impl(ctx):
     for dep in ctx.attr.deps:
         _inputs.extend(dep.files.to_list())
 
-    # _filename = "%{ctx.attr.gem_name}-%{ctx.attr.version}.gem"
-    # _file = ctx.actions.declare_file(_filename)
     ctx.actions.run(
         inputs = _inputs,
         executable = ctx.attr.ruby_interpreter.files_to_run.executable,

--- a/ruby/private/gem/gem.bzl
+++ b/ruby/private/gem/gem.bzl
@@ -1,0 +1,58 @@
+load("//ruby/private:providers.bzl", "RubyGem")
+
+# Runs gem with arbitrary arguments
+# eg: run_gem(runtime_ctx, ["install" "foo"])
+def _rb_build_gem_impl(ctx):
+    args = [
+        ctx.file._gem_runner.path,
+        "build",
+        ctx.attr.gemspec[RubyGem].gemspec.path,
+        "--output",
+        ctx.outputs.gem.path,
+    ]
+
+    _inputs = [ctx.file._gem_runner]
+    for dep in ctx.attr.deps:
+        _inputs.extend(dep.files.to_list())
+
+    # _filename = "%{ctx.attr.gem_name}-%{ctx.attr.version}.gem"
+    # _file = ctx.actions.declare_file(_filename)
+    ctx.actions.run(
+        inputs = _inputs,
+        executable = ctx.attr.ruby_interpreter.files_to_run.executable,
+        arguments = args,
+        outputs = [ctx.outputs.gem],
+    )
+
+_ATTRS = {
+    "ruby_sdk": attr.string(
+        default = "@org_ruby_lang_ruby_toolchain",
+    ),
+    "ruby_interpreter": attr.label(
+        default = "@org_ruby_lang_ruby_toolchain//:ruby_bin",
+        allow_files = True,
+        executable = True,
+        cfg = "host",
+    ),
+    "_gem_runner": attr.label(
+        default = Label("@coinbase_rules_ruby//ruby/private/gem:gem_runner.rb"),
+        allow_single_file = True,
+    ),
+    "gemspec": attr.label(
+        # allow_files = True,
+    ),
+    "gem_name": attr.string(
+    ),
+    "deps": attr.label_list(
+        allow_files = True,
+    ),
+    "version": attr.string(),
+}
+
+rb_build_gem = rule(
+    implementation = _rb_build_gem_impl,
+    attrs = _ATTRS,
+    outputs = {
+        "gem": "%{gem_name}-%{version}.gem",
+    },
+)

--- a/ruby/private/gem/gem_runner.rb
+++ b/ruby/private/gem/gem_runner.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rubygems'
+require 'rubygems/gem_runner'
+require 'rubygems/exceptions'
+
+require 'fileutils'
+
+required_version = Gem::Requirement.new '>= 1.8.7'
+
+abort "Expected Ruby Version #{required_version}, is #{Gem.ruby_version}" unless required_version.satisfied_by? Gem.ruby_version
+
+# Dereferences a file (converts it from a symlink to a real file Pinocchio)
+def dereference!(file)
+  return if !File.symlink?(file) || File.directory?(file)
+
+  tmpname = '/tmp' + File.expand_path(file)
+  FileUtils.mkdir_p(File.dirname(tmpname))
+  warn "copying #{file} to #{tmpname}"
+  FileUtils.cp(file, tmpname)
+  warn "moving #{tmpname} to #{file}"
+  FileUtils.mv(tmpname, file)
+end
+
+args = ARGV.clone
+
+# Gem builder does not like symlinks .. so make real files from any symlinks ..
+Dir.glob('./**/*').grep_v(%r{^\./bazel}).grep_v(%r{^\./external}) do |f|
+  dereference!(f)
+end
+
+begin
+  args = args.map do |arg|
+    if arg.include?('gemspec') && File.exist?(arg) # Jank hack -- gemspec file needs to be in same directory as the
+      # source files ..
+      FileUtils.copy(arg, File.basename(arg))
+      File.basename(arg)
+    else
+      arg
+    end
+  end
+
+  Gem::GemRunner.new.run args
+  # Dir.glob('./**/*').each { |f| warn f }
+rescue Gem::SystemExitException => e
+  exit e.exit_code
+end

--- a/ruby/private/gem/gem_runner.rb
+++ b/ruby/private/gem/gem_runner.rb
@@ -41,7 +41,6 @@ begin
   end
 
   Gem::GemRunner.new.run args
-  # Dir.glob('./**/*').each { |f| warn f }
 rescue Gem::SystemExitException => e
   exit e.exit_code
 end

--- a/ruby/private/gemspec.bzl
+++ b/ruby/private/gemspec.bzl
@@ -9,9 +9,6 @@ load(
 )
 
 def _get_transitive_srcs(srcs, deps):
-    for dep in deps:
-        print(dep[RubyLibrary].transitive_ruby_srcs)
-
     return depset(
         srcs,
         transitive = [dep[RubyLibrary].transitive_ruby_srcs for dep in deps],
@@ -54,6 +51,7 @@ def _rb_gem_impl(ctx):
         RubyGem(
             ctx = ctx,
             version = ctx.attr.version,
+            gemspec = gemspec,
         ),
     ]
 
@@ -76,6 +74,9 @@ _ATTRS = {
     "srcs": attr.label_list(
         allow_files = True,
         default = [],
+    ),
+    "gem_deps": attr.label_list(
+        allow_files = True,
     ),
     "require_paths": attr.string_list(),
 }

--- a/ruby/private/providers.bzl
+++ b/ruby/private/providers.bzl
@@ -20,5 +20,6 @@ RubyGem = provider(
     fields = [
         "ctx",
         "version",
+        "gemspec",
     ],
 )


### PR DESCRIPTION
rb_gem currently does not generate a valid `metadata.gz` file and a bunch of other things.

This PR changes the approach to generating gems a little bit:

Instead of generating and building the package in python, we make use of the ruby toolchain
and run the native gem generator