### PR TITLE
Add support for pre 3.0 rubygems

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ commands:
           command: |
             sudo curl -L -o /usr/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/v1.0/bazelisk-linux-amd64 \
             && sudo chmod +x /usr/bin/bazel
-  
+
   bazel-build-test-all:
     description: "Bazel build and test all"
     steps:
@@ -53,8 +53,8 @@ jobs:
     steps:
       - checkout
       - setup-bazel-env
-      - bazel-build-test-all 
-          
+      - bazel-build-test-all
+
   bazel_build_examples_simple_script:
     executor: base-executor
     working_directory: ~/project/examples/simple_script
@@ -62,13 +62,23 @@ jobs:
       - checkout:
           path: ~/project
       - setup-bazel-env
-      - bazel-build-test-all 
-      
+      - bazel-build-test-all
+
       - run:
           name: "Simple Script: Run bin and rubocop"
           command: |
             bazel run :bin \
             && bazel run :rubocop
+
+  bazel_build_examples_simple_script:
+    executor: base-executor
+    working_directory: ~/project/examples/example_gem
+    steps:
+      - checkout:
+          path: ~/project
+      - setup-bazel-env
+      - bazel-build-test-all
+
 
   buildifier:
     executor: base-executor
@@ -76,7 +86,7 @@ jobs:
     steps:
       - checkout
       - setup-bazel-env
-          
+
       - run:
           name: "Bazel Buildifier Run"
           command: |
@@ -87,5 +97,6 @@ workflows:
     jobs:
       - bazel_build_workspace
       - bazel_build_examples_simple_script
+      - bazel_build_examples_gem
       - buildifier
       - rubocop

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
             bazel run :bin \
             && bazel run :rubocop
 
-  bazel_build_examples_simple_script:
+  bazel_build_examples_gem:
     executor: base-executor
     working_directory: ~/project/examples/example_gem
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,9 @@ jobs:
       - checkout:
           path: ~/project
       - setup-bazel-env
-      - bazel-build-test-all
+      - run:
+          name: "Build all"
+          command: bazel build //...:all
 
 
   buildifier:

--- a/ruby/private/gem/gem.bzl
+++ b/ruby/private/gem/gem.bzl
@@ -7,7 +7,7 @@ def _rb_build_gem_impl(ctx):
         ctx.file._gem_runner.path,
         "build",
         ctx.attr.gemspec[RubyGem].gemspec.path,
-        "--output",
+        # Last arg should always be output path
         ctx.outputs.gem.path,
     ]
 

--- a/ruby/private/gem/gem_runner.rb
+++ b/ruby/private/gem/gem_runner.rb
@@ -3,6 +3,7 @@
 require 'rubygems'
 require 'rubygems/gem_runner'
 require 'rubygems/exceptions'
+require 'rubygems/version'
 
 require 'fileutils'
 
@@ -40,7 +41,21 @@ begin
     end
   end
 
+  output_path = args.pop()
+  post_build_copy = false
+  if Gem.rubygems_version < Gem::Version.new('3.0.0')
+    post_build_copy = true
+  else
+    args = args + ["--output", output_path]
+  end
+
   Gem::GemRunner.new.run args
+
+  if post_build_copy == true
+    # Move output to correct location
+    FileUtils.cp(File.basename(output_path), output_path)
+  end
 rescue Gem::SystemExitException => e
+  warn "bye"
   exit e.exit_code
 end

--- a/ruby/private/gem/gem_runner.rb
+++ b/ruby/private/gem/gem_runner.rb
@@ -46,14 +46,14 @@ begin
   if Gem.rubygems_version < Gem::Version.new('3.0.0')
     post_build_copy = true
   else
-    args += ["--output", output_path]
+    args += ['--output', output_path]
   end
 
   Gem::GemRunner.new.run args
 
   if post_build_copy == true
     # Move output to correct location
-    puts "Copying output gem to output_path due to pre 3.0.0 rubygems version"
+    puts 'Copying gem to output_path due to pre 3.0.0 rubygems version'
     FileUtils.cp(File.basename(output_path), output_path)
   end
 rescue Gem::SystemExitException => e

--- a/ruby/private/gem/gem_runner.rb
+++ b/ruby/private/gem/gem_runner.rb
@@ -17,9 +17,9 @@ def dereference!(file)
 
   tmpname = '/tmp' + File.expand_path(file)
   FileUtils.mkdir_p(File.dirname(tmpname))
-  warn "copying #{file} to #{tmpname}"
+  puts "copying #{file} to #{tmpname}"
   FileUtils.cp(file, tmpname)
-  warn "moving #{tmpname} to #{file}"
+  puts "moving #{tmpname} to #{file}"
   FileUtils.mv(tmpname, file)
 end
 
@@ -41,21 +41,21 @@ begin
     end
   end
 
-  output_path = args.pop()
+  output_path = args.pop
   post_build_copy = false
   if Gem.rubygems_version < Gem::Version.new('3.0.0')
     post_build_copy = true
   else
-    args = args + ["--output", output_path]
+    args += ["--output", output_path]
   end
 
   Gem::GemRunner.new.run args
 
   if post_build_copy == true
     # Move output to correct location
+    puts "Copying output gem to output_path due to pre 3.0.0 rubygems version"
     FileUtils.cp(File.basename(output_path), output_path)
   end
 rescue Gem::SystemExitException => e
-  warn "bye"
   exit e.exit_code
 end


### PR DESCRIPTION
The output flag for gem build was only added in 3.0.0. For systems with earlier versions we can manually copy the output to the correct directory.