### PR TITLE
Fix gem sandboxing

### DIFF
--- a/ruby/private/gem.bzl
+++ b/ruby/private/gem.bzl
@@ -9,7 +9,6 @@ load(
 
 def rb_gem(name, version, gem_name, srcs = [], **kwargs):
     _gemspec_name = name + "_gemspec"
-    tags = kwargs.pop("tags", [])
 
     _rb_gemspec(
         name = _gemspec_name,
@@ -19,17 +18,11 @@ def rb_gem(name, version, gem_name, srcs = [], **kwargs):
         **kwargs
     )
 
-    # _rb_build_gem does not support sandboxing because
-    # gem build cannot handle symlinks and needs to write
-    # the files as actual files.
-    tags.append("no-sandbox")
-
     _rb_build_gem(
         name = name,
         gem_name = gem_name,
         gemspec = _gemspec_name,
         version = version,
         deps = srcs + [_gemspec_name],
-        tags = tags,
         visibility = ["//visibility:public"],
     )

--- a/ruby/private/gem.bzl
+++ b/ruby/private/gem.bzl
@@ -14,7 +14,6 @@ def rb_gem(name, version, gem_name, srcs = [], **kwargs):
         name = _gemspec_name,
         gem_name = gem_name,
         version = version,
-        tags = tags,
         **kwargs
     )
 

--- a/ruby/private/gem.bzl
+++ b/ruby/private/gem.bzl
@@ -9,13 +9,20 @@ load(
 
 def rb_gem(name, version, gem_name, srcs = [], **kwargs):
     _gemspec_name = name + "_gemspec"
+    tags = kwargs.pop("tags", [])
 
     _rb_gemspec(
         name = _gemspec_name,
         gem_name = gem_name,
         version = version,
+        tags = tags,
         **kwargs
     )
+
+    # _rb_build_gem does not support sandboxing because
+    # gem build cannot handle symlinks and needs to write
+    # the files as actual files.
+    tags.append("no-sandbox")
 
     _rb_build_gem(
         name = name,
@@ -23,5 +30,6 @@ def rb_gem(name, version, gem_name, srcs = [], **kwargs):
         gemspec = _gemspec_name,
         version = version,
         deps = srcs + [_gemspec_name],
+        tags = tags,
         visibility = ["//visibility:public"],
     )

--- a/ruby/private/gem/gem.bzl
+++ b/ruby/private/gem/gem.bzl
@@ -15,11 +15,17 @@ def _rb_build_gem_impl(ctx):
     for dep in ctx.attr.deps:
         _inputs.extend(dep.files.to_list())
 
+    # the gem_runner does not support sandboxing because
+    # gem build cannot handle symlinks and needs to write
+    # the files as actual files.
     ctx.actions.run(
         inputs = _inputs,
         executable = ctx.attr.ruby_interpreter.files_to_run.executable,
         arguments = args,
         outputs = [ctx.outputs.gem],
+        execution_requirements = {
+            "no-sandbox": "1",
+        },
     )
 
 _ATTRS = {


### PR DESCRIPTION
When gem spawn strategy is sandbox we cannot build the gem rule because the gem build command does not allow writing to the filesystem. Actions support setting a no-sandbox execution requirement for these types of situations.