### PR TITLE
Gemspec generation needs to handle directories

### DIFF
--- a/ruby/private/gem/BUILD.bazel
+++ b/ruby/private/gem/BUILD.bazel
@@ -4,6 +4,7 @@ exports_files(
     [
         "gemspec_template.tpl",
         "gem_runner.rb",
+        "gemspec_builder.rb",
     ],
     visibility = ["//visibility:public"],
 )

--- a/ruby/private/gem/gemspec.bzl
+++ b/ruby/private/gem/gemspec.bzl
@@ -14,15 +14,6 @@ def _get_transitive_srcs(srcs, deps):
         transitive = [dep[RubyLibrary].transitive_ruby_srcs for dep in deps],
     )
 
-def _unique_elems(list):
-    _out = []
-    _prev = None
-    for elem in sorted(list):
-        if _prev != elem:
-            _out.append(elem)
-
-    return _out
-
 def _rb_gem_impl(ctx):
     gemspec = ctx.actions.declare_file("{}.gemspec".format(ctx.attr.gem_name))
     metadata_file = ctx.actions.declare_file("{}_metadata".format(ctx.attr.gem_name))

--- a/ruby/private/gem/gemspec_builder.rb
+++ b/ruby/private/gem/gemspec_builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'json'
 require 'optparse'
 
@@ -22,21 +24,21 @@ def parse_opts
     end
   end.parse!
 
-  return output_file, metadata_file, template_file
+  [output_file, metadata_file, template_file]
 end
 
 def add_src_file(src, new_srcs, new_require_paths)
-  if File.file?(src)
-    new_srcs << src
-    new_require_paths << File.dirname(src)
-  end
+  return unless File.file?(src)
+
+  new_srcs << src
+  new_require_paths << File.dirname(src)
 end
 
 def parse_metadata_srcs(metadata)
   # Files and required paths can include a directory which gemspec
   # cannot handle. This will convert directories to individual files
   # and update require_paths to include them..
-  srcs = metadata["srcs"]
+  srcs = metadata['srcs']
   new_require_paths = []
   new_srcs = []
   srcs.each do |src|
@@ -48,16 +50,16 @@ def parse_metadata_srcs(metadata)
       add_src_file(src, new_srcs, new_require_paths)
     end
   end
-  metadata["srcs"] = new_srcs
-  metadata["require_paths"] = new_require_paths
-  return metadata
+  metadata['srcs'] = new_srcs
+  metadata['require_paths'] = new_require_paths
+  metadata
 end
 
 def main
   output_file, metadata_file, template_file = parse_opts
   data = File.read(template_file)
-  f = File.read(metadata_file)
-  metadata = JSON.parse(f)
+  m = File.read(metadata_file)
+  metadata = JSON.parse(m)
 
   metadata = parse_metadata_srcs metadata
   filtered_data = data
@@ -67,8 +69,8 @@ def main
     filtered_data = filtered_data.gsub(replace_val, value.to_s)
   end
 
-  File.open(output_file, "w") do |f|
-    f.write(filtered_data)
+  File.open(output_file, 'w') do |out_file|
+    out_file.write(filtered_data)
   end
 end
 

--- a/ruby/private/gem/gemspec_builder.rb
+++ b/ruby/private/gem/gemspec_builder.rb
@@ -61,7 +61,7 @@ def main
   m = File.read(metadata_file)
   metadata = JSON.parse(m)
 
-  metadata = parse_metadata_srcs metadata
+  metadata = parse_metadata_srcs(metadata)
   filtered_data = data
 
   metadata.each do |key, value|

--- a/ruby/private/gem/gemspec_builder.rb
+++ b/ruby/private/gem/gemspec_builder.rb
@@ -1,0 +1,75 @@
+require 'json'
+require 'optparse'
+
+def parse_opts
+  output_file = nil
+  metadata_file = nil
+  template_file = nil
+
+  OptionParser.new do |opts|
+    opts.on('--template [ARG]', 'Gemspec template file') do |v|
+      template_file = v
+    end
+    opts.on('--output [ARG]', 'Output file') do |v|
+      output_file = v
+    end
+    opts.on('--metadata [ARG]', 'Metadata file') do |v|
+      metadata_file = v
+    end
+    opts.on('-h', '--help') do |_v|
+      puts opts
+      exit 0
+    end
+  end.parse!
+
+  return output_file, metadata_file, template_file
+end
+
+def add_src_file(src, new_srcs, new_require_paths)
+  if File.file?(src)
+    new_srcs << src
+    new_require_paths << File.dirname(src)
+  end
+end
+
+def parse_metadata_srcs(metadata)
+  # Files and required paths can include a directory which gemspec
+  # cannot handle. This will convert directories to individual files
+  # and update require_paths to include them..
+  srcs = metadata["srcs"]
+  new_require_paths = []
+  new_srcs = []
+  srcs.each do |src|
+    if File.directory?(src)
+      Dir.glob("#{src}/**/*") do |f|
+        add_src_file(f, new_srcs, new_require_paths)
+      end
+    else
+      add_src_file(src, new_srcs, new_require_paths)
+    end
+  end
+  metadata["srcs"] = new_srcs
+  metadata["require_paths"] = new_require_paths
+  return metadata
+end
+
+def main
+  output_file, metadata_file, template_file = parse_opts
+  data = File.read(template_file)
+  f = File.read(metadata_file)
+  metadata = JSON.parse(f)
+
+  metadata = parse_metadata_srcs metadata
+  filtered_data = data
+
+  metadata.each do |key, value|
+    replace_val = "{#{key}}"
+    filtered_data = filtered_data.gsub(replace_val, value.to_s)
+  end
+
+  File.open(output_file, "w") do |f|
+    f.write(filtered_data)
+  end
+end
+
+main if $PROGRAM_NAME == __FILE__

--- a/ruby/private/gem/gemspec_template.tpl
+++ b/ruby/private/gem/gemspec_template.tpl
@@ -1,8 +1,8 @@
 Gem::Specification.new do |s|
-  s.name          = {name}
-  s.summary       = {name}
+  s.name          = "{name}"
+  s.summary       = "{name}"
   s.authors       = {authors}
-  s.version       = {version}
+  s.version       = "{version}"
   s.files         = {srcs}
   s.require_paths = {require_paths}
 end


### PR DESCRIPTION
Some of our rules output a directory instead of a file. This is valid in Bazel, but gemspec cannot handle having a directory in the 'files' list so would error. This PR changes how we generate the gemspec file to be done via a ruby script instead of find/replace so that it can check for directories and then expand them to the full list of files. To ensure this will scale to gems that have thousands of files (it could happen...) it passes all the gem info/deps in using a generated metadata file.

Tested locally and also plugged it into an internal gem which was breaking due to this.