### PR TITLE
Add license field to gemspec, change require_paths to not include every path, add tests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ AllCops:
   DisplayCopNames: true
   Exclude:
     - "bazel-*/**/*"
+    - "ruby/tests/gemspec/expected/*"
 
 Layout/LineLength:
   Enabled: true

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -116,4 +116,5 @@ git_repository(
 )
 
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
 bazel_skylib_workspace()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -108,3 +108,12 @@ bundle_install(
 load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
 
 rules_pkg_dependencies()
+
+git_repository(
+    name = "wspace_bazel_skylib",
+    commit = "9935e0f820692f5f38e3b00c64ccbbff30cebe11",
+    remote = "https://github.com/bazelbuild/bazel-skylib",
+)
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+bazel_skylib_workspace()

--- a/examples/example_gem/BUILD
+++ b/examples/example_gem/BUILD
@@ -6,7 +6,6 @@ load(
 )
 
 rb_gem(
-    name = "default_gem",
     authors = ["Coinbase"],
     gem_name = "example_gem",
     version = "0.1.0",

--- a/examples/example_gem/BUILD
+++ b/examples/example_gem/BUILD
@@ -6,6 +6,7 @@ load(
 )
 
 rb_gem(
+    name = "example_gem",
     authors = ["Coinbase"],
     gem_name = "example_gem",
     version = "0.1.0",

--- a/ruby/private/gem/gemspec.bzl
+++ b/ruby/private/gem/gemspec.bzl
@@ -63,7 +63,6 @@ def _rb_gem_impl(ctx):
         ),
     ]
 
-
 _ATTRS = {
     "version": attr.string(
         default = "0.0.1",

--- a/ruby/private/gem/gemspec.bzl
+++ b/ruby/private/gem/gemspec.bzl
@@ -30,6 +30,8 @@ def _rb_gem_impl(ctx):
             srcs = _ruby_files,
             authors = ctx.attr.authors,
             version = ctx.attr.version,
+            licenses = ctx.attr.licenses,
+            require_paths = ctx.attr.require_paths,
         ).to_json(),
     )
 
@@ -61,11 +63,13 @@ def _rb_gem_impl(ctx):
         ),
     ]
 
+
 _ATTRS = {
     "version": attr.string(
         default = "0.0.1",
     ),
     "authors": attr.string_list(),
+    "licenses": attr.string_list(),
     "deps": attr.label_list(
         allow_files = True,
     ),

--- a/ruby/private/gem/gemspec.bzl
+++ b/ruby/private/gem/gemspec.bzl
@@ -52,6 +52,9 @@ def _rb_gem_impl(ctx):
             ctx.file._gemspec_template.path,
         ],
         outputs = [gemspec],
+        execution_requirements = {
+            "no-sandbox": "1",
+        },
     )
 
     return [

--- a/ruby/private/gem/gemspec_builder.rb
+++ b/ruby/private/gem/gemspec_builder.rb
@@ -50,11 +50,11 @@ def parse_metadata_srcs(metadata)
   new_srcs = []
   srcs.each do |src|
     if File.directory?(src)
-      Dir.glob("#{src}/**/*") do |f|
-        new_srcs << src if File.file?(src)
+      Dir.glob("#{src}/**/*") do |_f|
+        new_srcs << f if File.file?(f)
       end
-    else
-      new_srcs << src if File.file?(src)
+    elsif File.file?(src)
+      new_srcs << src
     end
   end
   metadata['srcs'] = new_srcs
@@ -66,7 +66,6 @@ def main
   data = File.read(template_file)
   m = File.read(metadata_file)
   metadata = JSON.parse(m)
-
 
   metadata = parse_metadata(metadata)
   filtered_data = data

--- a/ruby/private/gem/gemspec_builder.rb
+++ b/ruby/private/gem/gemspec_builder.rb
@@ -36,7 +36,7 @@ end
 
 def parse_require_paths(metadata)
   if metadata['require_paths'] == []
-    metadata['srcs'] do |f|
+    metadata['srcs'].each do |f|
       if File.basename(f, '.rb') == metadata['name']
         metadata['require_paths'] << File.dirname(f)
       end

--- a/ruby/private/gem/gemspec_builder.rb
+++ b/ruby/private/gem/gemspec_builder.rb
@@ -28,22 +28,24 @@ def parse_opts
 end
 
 def parse_metadata(metadata)
+  # Expand all of the sources first
+  metadata = expand_src_dirs(metadata)
   metadata = parse_require_paths(metadata)
-  metadata = parse_metadata_srcs(metadata)
   metadata
 end
 
 def parse_require_paths(metadata)
   if metadata['require_paths'] == []
-    expected_require_file = "#{metadata['name']}.rb"
-    Dir.glob("**/#{expected_require_file}") do |f|
-      metadata['require_paths'] << File.dirname(f)
+    metadata['srcs'] do |f|
+      if File.basename(f, '.rb') == metadata['name']
+        metadata['require_paths'] << File.dirname(f)
+      end
     end
   end
   metadata
 end
 
-def parse_metadata_srcs(metadata)
+def expand_src_dirs(metadata)
   # Files and required paths can include a directory which gemspec
   # cannot handle. This will convert directories to individual files
   srcs = metadata['srcs']

--- a/ruby/private/gem/gemspec_builder.rb
+++ b/ruby/private/gem/gemspec_builder.rb
@@ -37,9 +37,7 @@ end
 def parse_require_paths(metadata)
   if metadata['require_paths'] == []
     metadata['srcs'].each do |f|
-      if File.basename(f, '.rb') == metadata['name']
-        metadata['require_paths'] << File.dirname(f)
-      end
+      metadata['require_paths'] << File.dirname(f) if File.basename(f, '.rb') == metadata['name']
     end
   end
   metadata

--- a/ruby/private/gem/gemspec_template.tpl
+++ b/ruby/private/gem/gemspec_template.tpl
@@ -3,6 +3,7 @@ Gem::Specification.new do |s|
   s.summary       = "{name}"
   s.authors       = {authors}
   s.version       = "{version}"
+  s.licenses      = {licenses}
   s.files         = {srcs}
   s.require_paths = {require_paths}
 end

--- a/ruby/tests/gemspec/BUILD.bazel
+++ b/ruby/tests/gemspec/BUILD.bazel
@@ -1,0 +1,71 @@
+load("@wspace_bazel_skylib//rules:diff_test.bzl", "diff_test")
+load("@wspace_bazel_skylib//rules:select_file.bzl", "select_file")
+load("//ruby:defs.bzl", "rb_gemspec")
+
+rb_gemspec(
+    name = "licensed_gem",
+    authors = ["Coinbase"],
+    gem_name = "licensed_gem",
+    licenses = ["MIT"],
+    version = "0.1.0",
+    deps = [
+        "//ruby/tests/gemspec/lib:example_gem",
+    ],
+)
+
+select_file(
+    name = "select_license_spec",
+    srcs = ":licensed_gem",
+    subpath = "licensed_gem.gemspec",
+)
+
+diff_test(
+    name = "licensed_gem_test",
+    file1 = ":select_license_spec",
+    file2 = ":expected/licensed_gem.gemspec"
+)
+
+rb_gemspec(
+    name = "example_gem",
+    authors = ["Coinbase"],
+    gem_name = "example_gem",
+    version = "0.1.0",
+    deps = [
+        "//ruby/tests/gemspec/lib:example_gem",
+    ],
+)
+
+select_file(
+    name = "select_example_spec",
+    srcs = ":example_gem",
+    subpath = "example_gem.gemspec",
+)
+
+diff_test(
+    name = "example_gem_test",
+    file1 = ":select_example_spec",
+    file2 = ":expected/example_gem.gemspec"
+)
+
+rb_gemspec(
+    name = "require_gem",
+    authors = ["Coinbase"],
+    gem_name = "require_gem",
+    version = "0.1.0",
+    require_paths = ["ruby/tests/gemspec/lib/foo"],
+    deps = [
+        "//ruby/tests/gemspec/lib:example_gem",
+    ],
+)
+
+select_file(
+    name = "select_require_spec",
+    srcs = ":require_gem",
+    subpath = "require_gem.gemspec",
+)
+
+diff_test(
+    name = "require_gem_test",
+    file1 = ":select_require_spec",
+    file2 = ":expected/require_gem.gemspec"
+)

--- a/ruby/tests/gemspec/BUILD.bazel
+++ b/ruby/tests/gemspec/BUILD.bazel
@@ -22,7 +22,7 @@ select_file(
 diff_test(
     name = "licensed_gem_test",
     file1 = ":select_license_spec",
-    file2 = ":expected/licensed_gem.gemspec"
+    file2 = ":expected/licensed_gem.gemspec",
 )
 
 rb_gemspec(
@@ -44,15 +44,15 @@ select_file(
 diff_test(
     name = "example_gem_test",
     file1 = ":select_example_spec",
-    file2 = ":expected/example_gem.gemspec"
+    file2 = ":expected/example_gem.gemspec",
 )
 
 rb_gemspec(
     name = "require_gem",
     authors = ["Coinbase"],
     gem_name = "require_gem",
-    version = "0.1.0",
     require_paths = ["ruby/tests/gemspec/lib/foo"],
+    version = "0.1.0",
     deps = [
         "//ruby/tests/gemspec/lib:example_gem",
     ],
@@ -67,5 +67,5 @@ select_file(
 diff_test(
     name = "require_gem_test",
     file1 = ":select_require_spec",
-    file2 = ":expected/require_gem.gemspec"
+    file2 = ":expected/require_gem.gemspec",
 )

--- a/ruby/tests/gemspec/expected/example_gem.gemspec
+++ b/ruby/tests/gemspec/expected/example_gem.gemspec
@@ -1,0 +1,9 @@
+Gem::Specification.new do |s|
+  s.name          = "example_gem"
+  s.summary       = "example_gem"
+  s.authors       = ["Coinbase"]
+  s.version       = "0.1.0"
+  s.licenses      = []
+  s.files         = ["ruby/tests/gemspec/lib/foo/bar.rb", "ruby/tests/gemspec/lib/example_gem.rb"]
+  s.require_paths = ["ruby/tests/gemspec/lib"]
+end

--- a/ruby/tests/gemspec/expected/example_gem.gemspec
+++ b/ruby/tests/gemspec/expected/example_gem.gemspec
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 Gem::Specification.new do |s|
-  s.name          = "example_gem"
-  s.summary       = "example_gem"
-  s.authors       = ["Coinbase"]
-  s.version       = "0.1.0"
+  s.name          = 'example_gem'
+  s.summary       = 'example_gem'
+  s.authors       = ['Coinbase']
+  s.version       = '0.1.0'
   s.licenses      = []
-  s.files         = ["ruby/tests/gemspec/lib/foo/bar.rb", "ruby/tests/gemspec/lib/example_gem.rb"]
-  s.require_paths = ["ruby/tests/gemspec/lib"]
+  s.files         = ['ruby/tests/gemspec/lib/foo/bar.rb', 'ruby/tests/gemspec/lib/example_gem.rb']
+  s.require_paths = ['ruby/tests/gemspec/lib']
 end

--- a/ruby/tests/gemspec/expected/example_gem.gemspec
+++ b/ruby/tests/gemspec/expected/example_gem.gemspec
@@ -1,11 +1,9 @@
-# frozen_string_literal: true
-
 Gem::Specification.new do |s|
-  s.name          = 'example_gem'
-  s.summary       = 'example_gem'
-  s.authors       = ['Coinbase']
-  s.version       = '0.1.0'
+  s.name          = "example_gem"
+  s.summary       = "example_gem"
+  s.authors       = ["Coinbase"]
+  s.version       = "0.1.0"
   s.licenses      = []
-  s.files         = ['ruby/tests/gemspec/lib/foo/bar.rb', 'ruby/tests/gemspec/lib/example_gem.rb']
-  s.require_paths = ['ruby/tests/gemspec/lib']
+  s.files         = ["ruby/tests/gemspec/lib/foo/bar.rb", "ruby/tests/gemspec/lib/example_gem.rb"]
+  s.require_paths = ["ruby/tests/gemspec/lib"]
 end

--- a/ruby/tests/gemspec/expected/licensed_gem.gemspec
+++ b/ruby/tests/gemspec/expected/licensed_gem.gemspec
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 Gem::Specification.new do |s|
-  s.name          = "licensed_gem"
-  s.summary       = "licensed_gem"
-  s.authors       = ["Coinbase"]
-  s.version       = "0.1.0"
-  s.licenses      = ["MIT"]
-  s.files         = ["ruby/tests/gemspec/lib/foo/bar.rb", "ruby/tests/gemspec/lib/example_gem.rb"]
+  s.name          = 'licensed_gem'
+  s.summary       = 'licensed_gem'
+  s.authors       = ['Coinbase']
+  s.version       = '0.1.0'
+  s.licenses      = ['MIT']
+  s.files         = ['ruby/tests/gemspec/lib/foo/bar.rb', 'ruby/tests/gemspec/lib/example_gem.rb']
   s.require_paths = []
 end

--- a/ruby/tests/gemspec/expected/licensed_gem.gemspec
+++ b/ruby/tests/gemspec/expected/licensed_gem.gemspec
@@ -1,11 +1,9 @@
-# frozen_string_literal: true
-
 Gem::Specification.new do |s|
-  s.name          = 'licensed_gem'
-  s.summary       = 'licensed_gem'
-  s.authors       = ['Coinbase']
-  s.version       = '0.1.0'
-  s.licenses      = ['MIT']
-  s.files         = ['ruby/tests/gemspec/lib/foo/bar.rb', 'ruby/tests/gemspec/lib/example_gem.rb']
+  s.name          = "licensed_gem"
+  s.summary       = "licensed_gem"
+  s.authors       = ["Coinbase"]
+  s.version       = "0.1.0"
+  s.licenses      = ["MIT"]
+  s.files         = ["ruby/tests/gemspec/lib/foo/bar.rb", "ruby/tests/gemspec/lib/example_gem.rb"]
   s.require_paths = []
 end

--- a/ruby/tests/gemspec/expected/licensed_gem.gemspec
+++ b/ruby/tests/gemspec/expected/licensed_gem.gemspec
@@ -1,0 +1,9 @@
+Gem::Specification.new do |s|
+  s.name          = "licensed_gem"
+  s.summary       = "licensed_gem"
+  s.authors       = ["Coinbase"]
+  s.version       = "0.1.0"
+  s.licenses      = ["MIT"]
+  s.files         = ["ruby/tests/gemspec/lib/foo/bar.rb", "ruby/tests/gemspec/lib/example_gem.rb"]
+  s.require_paths = []
+end

--- a/ruby/tests/gemspec/expected/require_gem.gemspec
+++ b/ruby/tests/gemspec/expected/require_gem.gemspec
@@ -1,0 +1,9 @@
+Gem::Specification.new do |s|
+  s.name          = "require_gem"
+  s.summary       = "require_gem"
+  s.authors       = ["Coinbase"]
+  s.version       = "0.1.0"
+  s.licenses      = []
+  s.files         = ["ruby/tests/gemspec/lib/foo/bar.rb", "ruby/tests/gemspec/lib/example_gem.rb"]
+  s.require_paths = ["ruby/tests/gemspec/lib/foo"]
+end

--- a/ruby/tests/gemspec/expected/require_gem.gemspec
+++ b/ruby/tests/gemspec/expected/require_gem.gemspec
@@ -1,11 +1,9 @@
-# frozen_string_literal: true
-
 Gem::Specification.new do |s|
-  s.name          = 'require_gem'
-  s.summary       = 'require_gem'
-  s.authors       = ['Coinbase']
-  s.version       = '0.1.0'
+  s.name          = "require_gem"
+  s.summary       = "require_gem"
+  s.authors       = ["Coinbase"]
+  s.version       = "0.1.0"
   s.licenses      = []
-  s.files         = ['ruby/tests/gemspec/lib/foo/bar.rb', 'ruby/tests/gemspec/lib/example_gem.rb']
-  s.require_paths = ['ruby/tests/gemspec/lib/foo']
+  s.files         = ["ruby/tests/gemspec/lib/foo/bar.rb", "ruby/tests/gemspec/lib/example_gem.rb"]
+  s.require_paths = ["ruby/tests/gemspec/lib/foo"]
 end

--- a/ruby/tests/gemspec/expected/require_gem.gemspec
+++ b/ruby/tests/gemspec/expected/require_gem.gemspec
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 Gem::Specification.new do |s|
-  s.name          = "require_gem"
-  s.summary       = "require_gem"
-  s.authors       = ["Coinbase"]
-  s.version       = "0.1.0"
+  s.name          = 'require_gem'
+  s.summary       = 'require_gem'
+  s.authors       = ['Coinbase']
+  s.version       = '0.1.0'
   s.licenses      = []
-  s.files         = ["ruby/tests/gemspec/lib/foo/bar.rb", "ruby/tests/gemspec/lib/example_gem.rb"]
-  s.require_paths = ["ruby/tests/gemspec/lib/foo"]
+  s.files         = ['ruby/tests/gemspec/lib/foo/bar.rb', 'ruby/tests/gemspec/lib/example_gem.rb']
+  s.require_paths = ['ruby/tests/gemspec/lib/foo']
 end

--- a/ruby/tests/gemspec/lib/BUILD
+++ b/ruby/tests/gemspec/lib/BUILD
@@ -1,4 +1,5 @@
 package(default_visibility = ["//:__subpackages__"])
+
 load(
     "//ruby:defs.bzl",
     "rb_library",

--- a/ruby/tests/gemspec/lib/BUILD
+++ b/ruby/tests/gemspec/lib/BUILD
@@ -1,0 +1,11 @@
+package(default_visibility = ["//:__subpackages__"])
+load(
+    "//ruby:defs.bzl",
+    "rb_library",
+)
+
+rb_library(
+    name = "example_gem",
+    srcs = ["example_gem.rb"],
+    deps = ["//ruby/tests/gemspec/lib/foo:default_library"],
+)

--- a/ruby/tests/gemspec/lib/example_gem.rb
+++ b/ruby/tests/gemspec/lib/example_gem.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require_relative 'foo/bar'
+
+puts 'Foo'

--- a/ruby/tests/gemspec/lib/foo/BUILD
+++ b/ruby/tests/gemspec/lib/foo/BUILD
@@ -1,4 +1,5 @@
 package(default_visibility = ["//:__subpackages__"])
+
 load(
     "//ruby:defs.bzl",
     "rb_library",

--- a/ruby/tests/gemspec/lib/foo/BUILD
+++ b/ruby/tests/gemspec/lib/foo/BUILD
@@ -1,0 +1,10 @@
+package(default_visibility = ["//:__subpackages__"])
+load(
+    "//ruby:defs.bzl",
+    "rb_library",
+)
+
+rb_library(
+    name = "default_library",
+    srcs = ["bar.rb"],
+)

--- a/ruby/tests/gemspec/lib/foo/bar.rb
+++ b/ruby/tests/gemspec/lib/foo/bar.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Foo
+  class Bar
+    def call
+      puts 'Hello World'
+    end
+  end
+end


### PR DESCRIPTION
**New**
Added a licenses field to the gemspec.
Added tests for the gemspec.

**Changed**
require_paths was automatically adding every single available path to the gem. What is more common is gems have a single 'entrypoint' file that has the same name as the gem and does the requiring from there. This change will use the provided require_paths or will look for a file(s) with the same name as the gem and add that file's directory as the require path.