### PR TITLE
Correctly include generated files in gem, make gems reproducible

### DIFF
--- a/ruby/private/gem.bzl
+++ b/ruby/private/gem.bzl
@@ -9,6 +9,7 @@ load(
 
 def rb_gem(name, version, gem_name, srcs = [], **kwargs):
     _gemspec_name = name + "_gemspec"
+    deps = kwargs.get("deps", [])
 
     _rb_gemspec(
         name = _gemspec_name,
@@ -22,6 +23,6 @@ def rb_gem(name, version, gem_name, srcs = [], **kwargs):
         gem_name = gem_name,
         gemspec = _gemspec_name,
         version = version,
-        deps = srcs + [_gemspec_name],
+        deps = srcs + deps,
         visibility = ["//visibility:public"],
     )

--- a/ruby/private/gem.bzl
+++ b/ruby/private/gem.bzl
@@ -10,6 +10,7 @@ load(
 def rb_gem(name, version, gem_name, srcs = [], **kwargs):
     _gemspec_name = name + "_gemspec"
     deps = kwargs.get("deps", [])
+    source_date_epoch = kwargs.pop("source_date_epoch", None)
 
     _rb_gemspec(
         name = _gemspec_name,
@@ -25,4 +26,5 @@ def rb_gem(name, version, gem_name, srcs = [], **kwargs):
         version = version,
         deps = srcs + deps,
         visibility = ["//visibility:public"],
+        source_date_epoch = source_date_epoch,
     )

--- a/ruby/private/gem/gem.bzl
+++ b/ruby/private/gem/gem.bzl
@@ -22,7 +22,8 @@ def _rb_build_gem_impl(ctx):
         content = struct(
             srcs = _srcs,
             gemspec_path = gemspec.path,
-            output_path = ctx.outputs.gem.path
+            output_path = ctx.outputs.gem.path,
+            mtime =
         ).to_json(),
     )
     # the gem_runner does not support sandboxing because
@@ -65,6 +66,9 @@ _ATTRS = {
         allow_files = True,
     ),
     "version": attr.string(),
+    "source_date_epoch": attr.string(
+        docs = "Sets source_date_epoch env var which should make output gems hermetic",
+    ),
 }
 
 rb_build_gem = rule(

--- a/ruby/private/gem/gem.bzl
+++ b/ruby/private/gem/gem.bzl
@@ -26,6 +26,7 @@ def _rb_build_gem_impl(ctx):
             source_date_epoch = ctx.attr.source_date_epoch,
         ).to_json(),
     )
+
     # the gem_runner does not support sandboxing because
     # gem build cannot handle symlinks and needs to write
     # the files as actual files.

--- a/ruby/private/gem/gem.bzl
+++ b/ruby/private/gem/gem.bzl
@@ -5,11 +5,6 @@ load("//ruby/private:providers.bzl", "RubyGem")
 def _rb_build_gem_impl(ctx):
     metadata_file = ctx.actions.declare_file("{}_build_metadata".format(ctx.attr.gem_name))
     gemspec = ctx.attr.gemspec[RubyGem].gemspec
-    args = [
-        ctx.file._gem_runner.path,
-        "--metadata",
-        metadata_file.path,
-    ]
 
     _inputs = [ctx.file._gem_runner, metadata_file, gemspec]
     _srcs = []
@@ -36,7 +31,11 @@ def _rb_build_gem_impl(ctx):
     ctx.actions.run(
         inputs = _inputs,
         executable = ctx.attr.ruby_interpreter.files_to_run.executable,
-        arguments = args,
+        arguments = [
+            ctx.file._gem_runner.path,
+            "--metadata",
+            metadata_file.path,
+        ],
         outputs = [ctx.outputs.gem],
         execution_requirements = {
             "no-sandbox": "1",

--- a/ruby/private/gem/gem.bzl
+++ b/ruby/private/gem/gem.bzl
@@ -23,7 +23,7 @@ def _rb_build_gem_impl(ctx):
             srcs = _srcs,
             gemspec_path = gemspec.path,
             output_path = ctx.outputs.gem.path,
-            mtime =
+            source_date_epoch = ctx.attr.source_date_epoch,
         ).to_json(),
     )
     # the gem_runner does not support sandboxing because
@@ -67,7 +67,7 @@ _ATTRS = {
     ),
     "version": attr.string(),
     "source_date_epoch": attr.string(
-        docs = "Sets source_date_epoch env var which should make output gems hermetic",
+        doc = "Sets source_date_epoch env var which should make output gems hermetic",
     ),
 }
 

--- a/ruby/private/gem/gem_runner.rb
+++ b/ruby/private/gem/gem_runner.rb
@@ -52,7 +52,7 @@ end
 def do_build(dir, gemspec_path, output_path)
   args = [
     'build',
-    File.join(dir, File.basename(gemspec_path)),
+    File.join(dir, File.basename(gemspec_path))
   ]
 
   Gem::GemRunner.new.run args
@@ -75,9 +75,9 @@ def main
   m = File.read(metadata_file)
   metadata = JSON.parse(m)
 
-  if metadata["source_date_epoch"] != ""
+  if metadata['source_date_epoch'] != ''
     # I think this will make it hermetic! YAY!
-    ENV["SOURCE_DATE_EPOCH"] = metadata["source_date_epoch"]
+    ENV['SOURCE_DATE_EPOCH'] = metadata['source_date_epoch']
   end
 
   begin

--- a/ruby/private/gem/gem_runner.rb
+++ b/ruby/private/gem/gem_runner.rb
@@ -75,7 +75,7 @@ def main
   m = File.read(metadata_file)
   metadata = JSON.parse(m)
 
-  if metadata["source_data_epoch"]
+  if metadata["source_date_epoch"] != ""
     # I think this will make it hermetic! YAY!
     ENV["SOURCE_DATE_EPOCH"] = metadata["source_date_epoch"]
   end

--- a/ruby/private/gem/gem_runner.rb
+++ b/ruby/private/gem/gem_runner.rb
@@ -75,6 +75,11 @@ def main
   m = File.read(metadata_file)
   metadata = JSON.parse(m)
 
+  if metadata["source_data_epoch"]
+    # I think this will make it hermetic! YAY!
+    ENV["SOURCE_DATE_EPOCH"] = metadata["source_date_epoch"]
+  end
+
   begin
     build_gem(metadata)
   rescue Gem::SystemExitException => e

--- a/ruby/private/gem/gem_runner.rb
+++ b/ruby/private/gem/gem_runner.rb
@@ -1,61 +1,85 @@
 # frozen_string_literal: true
 
+require 'fileutils'
+require 'json'
+require 'optparse'
 require 'rubygems'
 require 'rubygems/gem_runner'
 require 'rubygems/exceptions'
 require 'rubygems/version'
+require 'tmpdir'
 
-require 'fileutils'
+def check_rubygems_version
+  required_version = Gem::Requirement.new '>= 1.8.7'
 
-required_version = Gem::Requirement.new '>= 1.8.7'
-
-abort "Expected Ruby Version #{required_version}, is #{Gem.ruby_version}" unless required_version.satisfied_by? Gem.ruby_version
-
-# Dereferences a file (converts it from a symlink to a real file Pinocchio)
-def dereference!(file)
-  return if !File.symlink?(file) || File.directory?(file)
-
-  tmpname = '/tmp' + File.expand_path(file)
-  FileUtils.mkdir_p(File.dirname(tmpname))
-  puts "copying #{file} to #{tmpname}"
-  FileUtils.cp(file, tmpname)
-  puts "moving #{tmpname} to #{file}"
-  FileUtils.mv(tmpname, file)
+  abort "Expected Ruby Version #{required_version}, is #{Gem.ruby_version}" unless required_version.satisfied_by? Gem.ruby_version
 end
 
-args = ARGV.clone
+def parse_opts
+  metadata_file = nil
 
-# Gem builder does not like symlinks .. so make real files from any symlinks ..
-Dir.glob('./**/*').grep_v(%r{^\./bazel}).grep_v(%r{^\./external}) do |f|
-  dereference!(f)
-end
-
-begin
-  args = args.map do |arg|
-    if arg.include?('gemspec') && File.exist?(arg) # Jank hack -- gemspec file needs to be in same directory as the
-      # source files ..
-      FileUtils.copy(arg, File.basename(arg))
-      File.basename(arg)
-    else
-      arg
+  OptionParser.new do |opts|
+    opts.on('--metadata [ARG]', 'Metadata file') do |v|
+      metadata_file = v
     end
-  end
+    opts.on('-h', '--help') do |_v|
+      puts opts
+      exit 0
+    end
+  end.parse!
 
-  output_path = args.pop
-  post_build_copy = false
-  if Gem.rubygems_version < Gem::Version.new('3.0.0')
-    post_build_copy = true
-  else
-    args += ['--output', output_path]
+  metadata_file
+end
+
+def copy_srcs(dir, srcs)
+  # Sources need to be moved from their bazel_out locations
+  # to the correct folder in the ruby gem.
+  srcs.each do |src|
+    src_path = src['src_path']
+    dest_path = src['dest_path']
+    tmpname = File.join(dir, File.dirname(dest_path))
+    FileUtils.mkdir_p(tmpname)
+    puts "copying #{src_path} to #{tmpname}"
+    FileUtils.cp_r(src_path, tmpname)
   end
+end
+
+def copy_gemspec(dir, gemspec_path)
+  # The gemspec file needs to be in the root of the build dir
+  FileUtils.cp(gemspec_path, dir)
+end
+
+def do_build(dir, gemspec_path, output_path)
+  args = [
+    'build',
+    File.join(dir, File.basename(gemspec_path)),
+  ]
 
   Gem::GemRunner.new.run args
-
-  if post_build_copy == true
-    # Move output to correct location
-    puts 'Copying gem to output_path due to pre 3.0.0 rubygems version'
-    FileUtils.cp(File.basename(output_path), output_path)
-  end
-rescue Gem::SystemExitException => e
-  exit e.exit_code
+  FileUtils.cp(File.join(dir, File.basename(output_path)), output_path)
 end
+
+def build_gem(metadata)
+  # We copy all related files to a tmpdir, build the entire gem in that tmpdir
+  # and then copy the output gem into the correct bazel output location.
+  Dir.mktmpdir do |dir|
+    copy_srcs(dir, metadata['srcs'])
+    copy_gemspec(dir, metadata['gemspec_path'])
+    do_build(dir, metadata['gemspec_path'], metadata['output_path'])
+  end
+end
+
+def main
+  check_rubygems_version
+  metadata_file = parse_opts
+  m = File.read(metadata_file)
+  metadata = JSON.parse(m)
+
+  begin
+    build_gem(metadata)
+  rescue Gem::SystemExitException => e
+    exit e.exit_code
+  end
+end
+
+main if $PROGRAM_NAME == __FILE__

--- a/ruby/private/gem/gemspec.bzl
+++ b/ruby/private/gem/gemspec.bzl
@@ -21,13 +21,19 @@ def _rb_gem_impl(ctx):
     _ruby_files = []
     file_deps = _get_transitive_srcs([], ctx.attr.deps).to_list()
     for f in file_deps:
-        _ruby_files.append(f.short_path)
+      # For some files the src_path and dest_path will be the same, but
+      # for othrs the src_path will be in bazel)out while the dest_path
+      # will be from the workspace root.
+        _ruby_files.append({
+            "src_path": f.path,
+            "dest_path": f.short_path,
+        })
 
     ctx.actions.write(
         output = metadata_file,
         content = struct(
             name = ctx.attr.gem_name,
-            srcs = _ruby_files,
+            raw_srcs = _ruby_files,
             authors = ctx.attr.authors,
             version = ctx.attr.version,
             licenses = ctx.attr.licenses,

--- a/ruby/private/gem/gemspec.bzl
+++ b/ruby/private/gem/gemspec.bzl
@@ -21,9 +21,9 @@ def _rb_gem_impl(ctx):
     _ruby_files = []
     file_deps = _get_transitive_srcs([], ctx.attr.deps).to_list()
     for f in file_deps:
-      # For some files the src_path and dest_path will be the same, but
-      # for othrs the src_path will be in bazel)out while the dest_path
-      # will be from the workspace root.
+        # For some files the src_path and dest_path will be the same, but
+        # for othrs the src_path will be in bazel)out while the dest_path
+        # will be from the workspace root.
         _ruby_files.append({
             "src_path": f.path,
             "dest_path": f.short_path,

--- a/ruby/private/gem/gemspec_builder.rb
+++ b/ruby/private/gem/gemspec_builder.rb
@@ -46,15 +46,18 @@ end
 def expand_src_dirs(metadata)
   # Files and required paths can include a directory which gemspec
   # cannot handle. This will convert directories to individual files
-  srcs = metadata['srcs']
+  srcs = metadata['raw_srcs']
   new_srcs = []
   srcs.each do |src|
-    if File.directory?(src)
-      Dir.glob("#{src}/**/*") do |_f|
-        new_srcs << f if File.file?(f)
+    src_path = src["src_path"]
+    dest_path = src["dest_path"]
+    if File.directory?(src_path)
+      Dir.glob("#{src_path}/**/*") do |f|
+        # expand the directory, replacing each src path with its dest path
+        new_srcs << f.gsub(src_path, dest_path) if File.file?(f)
       end
-    elsif File.file?(src)
-      new_srcs << src
+    elsif File.file?(src_path)
+      new_srcs << src_path
     end
   end
   metadata['srcs'] = new_srcs
@@ -66,6 +69,7 @@ def main
   data = File.read(template_file)
   m = File.read(metadata_file)
   metadata = JSON.parse(m)
+  puts metadata
 
   metadata = parse_metadata(metadata)
   filtered_data = data

--- a/ruby/private/gem/gemspec_builder.rb
+++ b/ruby/private/gem/gemspec_builder.rb
@@ -49,8 +49,8 @@ def expand_src_dirs(metadata)
   srcs = metadata['raw_srcs']
   new_srcs = []
   srcs.each do |src|
-    src_path = src["src_path"]
-    dest_path = src["dest_path"]
+    src_path = src['src_path']
+    dest_path = src['dest_path']
     if File.directory?(src_path)
       Dir.glob("#{src_path}/**/*") do |f|
         # expand the directory, replacing each src path with its dest path


### PR DESCRIPTION
This PR rewrites a lot of the gem_runner code in order to make gems include generated files more cleanly.

**Current behaviour**
Gem files are copied to a tmpdir and then back to the bazel-out directory so that they are not symlinks and so that they are at the correct path for the gem build command to execute. This does not include moving generated files (that are at a bazel-out path and not directly in the pwd) and involves globbing for files in the directory which can capture more files than is needed (eg. BUILD files).

**New behaviour**
A metadata file is created that includes a json dict of all variables that need to be present for gem_runner (instead of flags). All dependent files are passed to the gem_runner command and include their actual path and their short path. For source files these two will be the same, but for generated files the path is a longer bazel-out directory and the short path is where they need to be for the ruby gem to work.
All of the dependent files (and gemspec) are copied to the correct location in a generated tmpdir. The gem build is then done in that tmpdir and the output gem is copied to the correct location within the bazel-out context. This reduces file movement and means we aren't as likely to mess up our bazel-out directory.

**Reproducible gem builds**
Found that ruby gems supports (perhaps only recently) the source_date_epoch env var that allows for reproducible builds. Tested locally and found that with that env var set I was able to generate ruby gems at different times with the same md5 sum.