### PR TITLE
Dereference symlinks and include chdir

### DIFF
--- a/ruby/private/gem.bzl
+++ b/ruby/private/gem.bzl
@@ -11,6 +11,7 @@ def rb_gem(name, version, gem_name, srcs = [], **kwargs):
     _gemspec_name = name + "_gemspec"
     deps = kwargs.get("deps", [])
     source_date_epoch = kwargs.pop("source_date_epoch", None)
+    verbose = kwargs.pop("verbose", False)
 
     _rb_gemspec(
         name = _gemspec_name,
@@ -27,4 +28,5 @@ def rb_gem(name, version, gem_name, srcs = [], **kwargs):
         deps = srcs + deps,
         visibility = ["//visibility:public"],
         source_date_epoch = source_date_epoch,
+        verbose = verbose,
     )

--- a/ruby/private/gem/gem.bzl
+++ b/ruby/private/gem/gem.bzl
@@ -24,6 +24,7 @@ def _rb_build_gem_impl(ctx):
             gemspec_path = gemspec.path,
             output_path = ctx.outputs.gem.path,
             source_date_epoch = ctx.attr.source_date_epoch,
+            verbose = ctx.attr.verbose,
         ).to_json(),
     )
 
@@ -70,6 +71,7 @@ _ATTRS = {
     "source_date_epoch": attr.string(
         doc = "Sets source_date_epoch env var which should make output gems hermetic",
     ),
+    "verbose": attr.bool(default=False),
 }
 
 rb_build_gem = rule(

--- a/ruby/private/gem/gem.bzl
+++ b/ruby/private/gem/gem.bzl
@@ -71,7 +71,7 @@ _ATTRS = {
     "source_date_epoch": attr.string(
         doc = "Sets source_date_epoch env var which should make output gems hermetic",
     ),
-    "verbose": attr.bool(default=False),
+    "verbose": attr.bool(default = False),
 }
 
 rb_build_gem = rule(

--- a/ruby/private/gem/gem_runner.rb
+++ b/ruby/private/gem/gem_runner.rb
@@ -52,7 +52,8 @@ def dereference_symlinks(dir, verbose)
     if File.symlink?(src)
       actual_src = File.realpath(src)
       puts "Dereferencing symlink at #{src} to #{actual_src}" if verbose
-      FileUtils.cp_r(actual_src, src, remove_destination: true)
+      FileUtils.safe_unlink(src)
+      FileUtils.cp_r(actual_src, src)
     end
   end
 end

--- a/ruby/private/gem/gem_runner.rb
+++ b/ruby/private/gem/gem_runner.rb
@@ -52,7 +52,7 @@ def dereference_symlinks(dir, verbose)
     if File.symlink?(src)
       actual_src = File.realpath(src)
       puts "Dereferencing symlink at #{src} to #{actual_src}" if verbose
-      FileUtils.cp_r(actual_src, src)
+      FileUtils.cp_r(actual_src, src, remove_destination=true)
     end
   end
 end

--- a/ruby/private/gem/gem_runner.rb
+++ b/ruby/private/gem/gem_runner.rb
@@ -52,7 +52,7 @@ def dereference_symlinks(dir, verbose)
     if File.symlink?(src)
       actual_src = File.realpath(src)
       puts "Dereferencing symlink at #{src} to #{actual_src}" if verbose
-      FileUtils.cp_r(actual_src, src, remove_destination=true)
+      FileUtils.cp_r(actual_src, src, remove_destination: true)
     end
   end
 end

--- a/ruby/private/gem/gem_runner.rb
+++ b/ruby/private/gem/gem_runner.rb
@@ -43,9 +43,7 @@ def copy_srcs(dir, srcs, verbose)
     FileUtils.cp_r(src_path, tmpname)
     # Copying a directory will not dereference symlinks
     # in the directory. They need to be removed too.
-    if File.directory?(tmpname)
-      dereference_symlinks(tmpname, verbose)
-    end
+    dereference_symlinks(tmpname, verbose) if File.directory?(tmpname)
   end
 end
 

--- a/ruby/private/gem/gemspec_builder.rb
+++ b/ruby/private/gem/gemspec_builder.rb
@@ -69,7 +69,6 @@ def main
   data = File.read(template_file)
   m = File.read(metadata_file)
   metadata = JSON.parse(m)
-  puts metadata
 
   metadata = parse_metadata(metadata)
   filtered_data = data


### PR DESCRIPTION
It seems like different versions of RubyGems have different behaviour around where they output the gem when the gem folder and the cwd don't match. In order to keep the behaviour consistent we now chdir into the tmp gem folder so that it matches the cwd.

Also, cp_r only dereference sthe root file/folder in a tree and not any symlinks that are nested inside that tree. We now detect if a folder was copied and then attempt to dereference any files inside that folder.

Added a verbose flag to control output.