### PR TITLE
gemspec_builder.rb should use dest_path

### DIFF
--- a/ruby/private/gem/gemspec_builder.rb
+++ b/ruby/private/gem/gemspec_builder.rb
@@ -57,7 +57,7 @@ def expand_src_dirs(metadata)
         new_srcs << f.gsub(src_path, dest_path) if File.file?(f)
       end
     elsif File.file?(src_path)
-      new_srcs << src_path
+      new_srcs << dest_path
     end
   end
   metadata['srcs'] = new_srcs


### PR DESCRIPTION
src_path is the actual file location (for generated files this is in bazel-out) while dest_path is the file location we expect it to end up at (ie from the root of the workspace). For actual source files these are the same, but for generated files they are different and we should use the dest_path when building out the gemspec info.