### PR TITLE
Add run_under, fix gem pristine

### DIFF
--- a/ruby/private/binary.bzl
+++ b/ruby/private/binary.bzl
@@ -69,6 +69,7 @@ def rb_binary_macro(ctx, main, srcs):
             "{gem_path}": gem_path,
             "{should_gem_pristine}": str(len(gems_to_pristine) > 0).lower(),
             "{gems_to_pristine}": " ".join(gems_to_pristine),
+            "{run_under}": ctx.attr.run_under,
         },
     )
 

--- a/ruby/private/binary_wrapper.tpl
+++ b/ruby/private/binary_wrapper.tpl
@@ -110,8 +110,8 @@ def main(args)
   runfiles_envkey, runfiles_envvalue = runfiles_envvar(runfiles)
   ENV[runfiles_envkey] = runfiles_envvalue if runfiles_envkey
 
-  ENV["GEM_PATH"] = File.join(runfiles, "{gem_path}") if "{gem_path}"
-  ENV["GEM_HOME"] = File.join(runfiles, "{gem_path}") if "{gem_path}"
+  ENV["GEM_PATH"] = File.join(runfiles, "{gem_path}") if "{gem_path}" != ""
+  ENV["GEM_HOME"] = File.join(runfiles, "{gem_path}") if "{gem_path}" != ""
 
   ruby_program = find_rb_binary
 
@@ -136,6 +136,10 @@ def main(args)
     gem_program = find_gem_binary
     puts "Running pristine on {gems_to_pristine}"
     system(gem_program + " pristine {gems_to_pristine}")
+  end
+
+  if "{run_under}" != "" then
+    Dir.chdir("{run_under}")
   end
 
   exec(ruby_program, *rubyopt, main, *args)

--- a/ruby/private/bundle/create_bundle_build_file.rb
+++ b/ruby/private/bundle/create_bundle_build_file.rb
@@ -28,6 +28,8 @@ TEMPLATE = <<~MAIN_TEMPLATE
   # PULL EACH GEM INDIVIDUALLY
 MAIN_TEMPLATE
 
+# The build_complete file is only silence the 'extensions' are not built warnings. They are built.
+# TODO: Replace the extensions ** with the platform (eg. x86_64-darwin-19)
 GEM_TEMPLATE = <<~GEM_TEMPLATE
   rb_library(
     name = "{name}",
@@ -36,6 +38,7 @@ GEM_TEMPLATE = <<~GEM_TEMPLATE
         "lib/ruby/{ruby_version}/gems/{name}-{version}*/**",
         "lib/ruby/{ruby_version}/specifications/{name}-{version}*.gemspec",
         "lib/ruby/{ruby_version}/cache/{name}-{version}*.gem",
+        "lib/ruby/{ruby_version}/extensions/**/{ruby_version}/{name}-{version}/gem.build_complete",
         "bin/*"
       ],
       exclude = {exclude},

--- a/ruby/private/constants.bzl
+++ b/ruby/private/constants.bzl
@@ -25,6 +25,9 @@ RUBY_ATTRS = {
     "force_gem_pristine": attr.string_list(
         doc = "Jank hack. Run gem pristine on some gems that don't handle symlinks well",
     ),
+    "run_under": attr.string(
+        doc = "Execute a directory change before running the binary.",
+    ),
     "_wrapper_template": attr.label(
         allow_single_file = True,
         default = "binary_wrapper.tpl",


### PR DESCRIPTION
**Experimental:** Add run_under to the rb_binary rule that will execute a chdir into the specified directory before executing the ruby command. This is intended to make it easier to use projects/tools that tightly couple the cwd with the root of the ruby project.

Also, include the .complete files from when gems build native extensions to silence the warnings about extensions not being built. Yes, this file is how it determines if the native extension is built and has absolutely nothing to do with if the file is actually built