### PR TITLE
Fix bundler support

### DIFF
--- a/ruby/private/binary/binary.bzl
+++ b/ruby/private/binary/binary.bzl
@@ -18,11 +18,11 @@ def _get_gem_path(incpaths):
     """
     if len(incpaths) == 0:
         return ""
-    # This may cause issues if the only gem is bundler... but we will cross that bridge when we come to it
     for incpath in incpaths:
       if "/lib/ruby/" in incpath and "/gems/" in incpath:
         return incpath.rsplit("/", 3)[0]
-    fail("Could not find gem path from include path")
+    # if none match the lib ruby setup then we will default to the first one
+    return incpaths[0].rsplit("/", 3)[0]
 
 def _get_bundle_path(gem_path):
     """

--- a/ruby/private/binary/binary.bzl
+++ b/ruby/private/binary/binary.bzl
@@ -18,8 +18,11 @@ def _get_gem_path(incpaths):
     """
     if len(incpaths) == 0:
         return ""
-    incpath = incpaths[0]
-    return incpath.rsplit("/", 3)[0]
+    # This may cause issues if the only gem is bundler... but we will cross that bridge when we come to it
+    for incpath in incpaths:
+      if "/lib/ruby/" in incpath and "/gems/" in incpath:
+        return incpath.rsplit("/", 3)[0]
+    fail("Could not find gem path from include path")
 
 def _get_bundle_path(gem_path):
     """

--- a/ruby/private/binary/binary.bzl
+++ b/ruby/private/binary/binary.bzl
@@ -19,8 +19,9 @@ def _get_gem_path(incpaths):
     if len(incpaths) == 0:
         return ""
     for incpath in incpaths:
-      if "/lib/ruby/" in incpath and "/gems/" in incpath:
-        return incpath.rsplit("/", 3)[0]
+        if "/lib/ruby/" in incpath and "/gems/" in incpath:
+            return incpath.rsplit("/", 3)[0]
+
     # if none match the lib ruby setup then we will default to the first one
     return incpaths[0].rsplit("/", 3)[0]
 

--- a/ruby/private/bundle/bundle.bzl
+++ b/ruby/private/bundle/bundle.bzl
@@ -64,6 +64,7 @@ def generate_bundle_build_file(runtime_ctx):
         runtime_ctx.ctx.name,  # Name of the target
         repr(runtime_ctx.ctx.attr.excludes),
         RULES_RUBY_WORKSPACE_NAME,
+        runtime_ctx.bundler_version,
     ]
 
     result = runtime_ctx.ctx.execute(

--- a/ruby/private/bundle/create_bundle_build_file.rb
+++ b/ruby/private/bundle/create_bundle_build_file.rb
@@ -78,12 +78,14 @@ class BundleBuildFileGenerator
               :ruby_version,
               :bundler_version
 
+  # rubocop:disable Metrics/ParameterLists
   def initialize(workspace_name:,
                  repo_name:,
                  bundler_version:,
                  build_file: 'BUILD.bazel',
                  gemfile_lock: 'Gemfile.lock',
                  excludes: nil)
+    # rubocop:enable Metrics/ParameterLists
     @workspace_name = workspace_name
     @repo_name      = repo_name
     @build_file     = build_file
@@ -184,6 +186,5 @@ if $PROGRAM_NAME == __FILE__
                                repo_name: repo_name,
                                excludes: JSON.parse(excludes),
                                workspace_name: workspace_name,
-                               bundler_version: bundler_version
-                          ).generate!
+                               bundler_version: bundler_version).generate!
 end


### PR DESCRIPTION
Bundler didn't have the correct rubyopt/includes setup. This adds the info for that so that we don't accidentally load system bundler.