### PR TITLE
Handle mapping to different paths to gems

### DIFF
--- a/ruby/private/gem.bzl
+++ b/ruby/private/gem.bzl
@@ -11,10 +11,10 @@ def rb_gem(name, version, gem_name, srcs = [], **kwargs):
     _gemspec_name = name + "_gemspec"
     deps = kwargs.get("deps", [])
     source_date_epoch = kwargs.pop("source_date_epoch", None)
+    strip_paths = kwargs.pop("strip_paths", [])
     verbose = kwargs.pop("verbose", False)
 
-    strip_paths = []
-    if "strip_paths" in kwargs and "require_paths" not in kwargs:
+    if strip_paths and "require_paths" not in kwargs:
         fail("Must specify 'require_paths' when using the 'strip_paths' argument")
 
     _rb_gemspec(

--- a/ruby/private/gem.bzl
+++ b/ruby/private/gem.bzl
@@ -11,7 +11,7 @@ def rb_gem(name, version, gem_name, **kwargs):
     _gemspec_name = name + "_gemspec"
     deps = kwargs.get("deps", [])
     source_date_epoch = kwargs.pop("source_date_epoch", None)
-    srcs = kwargs.pop("src", [])
+    srcs = kwargs.pop("srcs", [])
     strip_paths = kwargs.pop("strip_paths", [])
     verbose = kwargs.pop("verbose", False)
 

--- a/ruby/private/gem.bzl
+++ b/ruby/private/gem.bzl
@@ -7,10 +7,11 @@ load(
     _rb_build_gem = "rb_build_gem",
 )
 
-def rb_gem(name, version, gem_name, srcs = [], **kwargs):
+def rb_gem(name, version, gem_name, **kwargs):
     _gemspec_name = name + "_gemspec"
     deps = kwargs.get("deps", [])
     source_date_epoch = kwargs.pop("source_date_epoch", None)
+    srcs = kwargs.pop("src", [])
     strip_paths = kwargs.pop("strip_paths", [])
     verbose = kwargs.pop("verbose", False)
 

--- a/ruby/private/gem.bzl
+++ b/ruby/private/gem.bzl
@@ -13,10 +13,15 @@ def rb_gem(name, version, gem_name, srcs = [], **kwargs):
     source_date_epoch = kwargs.pop("source_date_epoch", None)
     verbose = kwargs.pop("verbose", False)
 
+    strip_paths = []
+    if "strip_paths" in kwargs and "require_paths" not in kwargs:
+        fail("Must specify 'require_paths' when using the 'strip_paths' argument")
+
     _rb_gemspec(
         name = _gemspec_name,
         gem_name = gem_name,
         version = version,
+        strip_paths = strip_paths,
         **kwargs
     )
 
@@ -28,5 +33,6 @@ def rb_gem(name, version, gem_name, srcs = [], **kwargs):
         deps = srcs + deps,
         visibility = ["//visibility:public"],
         source_date_epoch = source_date_epoch,
+        strip_paths = strip_paths,
         verbose = verbose,
     )

--- a/ruby/private/gem/gem.bzl
+++ b/ruby/private/gem/gem.bzl
@@ -1,4 +1,5 @@
 load("//ruby/private:providers.bzl", "RubyGem")
+load("//ruby/private/tools:paths.bzl", "strip_short_path")
 
 # Runs gem with arbitrary arguments
 # eg: run_gem(runtime_ctx, ["install" "foo"])
@@ -12,9 +13,10 @@ def _rb_build_gem_impl(ctx):
         file_deps = dep.files.to_list()
         _inputs.extend(file_deps)
         for f in file_deps:
+            dest_path = strip_short_path(f.short_path, ctx.attr.strip_paths)
             _srcs.append({
                 "src_path": f.path,
-                "dest_path": f.short_path,
+                "dest_path": dest_path,
             })
 
     ctx.actions.write(
@@ -71,6 +73,7 @@ _ATTRS = {
     "source_date_epoch": attr.string(
         doc = "Sets source_date_epoch env var which should make output gems hermetic",
     ),
+    "strip_paths": attr.string_list(),
     "verbose": attr.bool(default = False),
 }
 

--- a/ruby/private/gem/gemspec.bzl
+++ b/ruby/private/gem/gemspec.bzl
@@ -2,6 +2,7 @@ load(
     "//ruby/private/tools:deps.bzl",
     _transitive_deps = "transitive_deps",
 )
+load("//ruby/private/tools:paths.bzl", "strip_short_path")
 load(
     "//ruby/private:providers.bzl",
     "RubyGem",
@@ -24,9 +25,10 @@ def _rb_gem_impl(ctx):
         # For some files the src_path and dest_path will be the same, but
         # for othrs the src_path will be in bazel)out while the dest_path
         # will be from the workspace root.
+        dest_path = strip_short_path(f.short_path, ctx.attr.strip_paths)
         _ruby_files.append({
             "src_path": f.path,
-            "dest_path": f.short_path,
+            "dest_path": dest_path,
         })
 
     ctx.actions.write(
@@ -99,6 +101,7 @@ _ATTRS = {
         default = [],
     ),
     "require_paths": attr.string_list(),
+    "strip_paths": attr.string_list(),
     "_gemspec_template": attr.label(
         allow_single_file = True,
         default = "gemspec_template.tpl",

--- a/ruby/private/tools/paths.bzl
+++ b/ruby/private/tools/paths.bzl
@@ -1,0 +1,12 @@
+def strip_short_path(path, strip_paths):
+    """ Given a short_path string will iterate over the
+    list of strip_paths and remove any matches returning a
+    new path string with no leading slash.
+    """
+    if not strip_paths:
+        return path
+
+    for strip_path in strip_paths:
+        if path.startswith(strip_path):
+            return path.replace(strip_path, "").lstrip("/")
+    return path

--- a/ruby/tests/gemspec/BUILD.bazel
+++ b/ruby/tests/gemspec/BUILD.bazel
@@ -1,9 +1,8 @@
-load("@wspace_bazel_skylib//rules:diff_test.bzl", "diff_test")
-load("@wspace_bazel_skylib//rules:select_file.bzl", "select_file")
-load("//ruby:defs.bzl", "rb_gemspec")
+load("//ruby/tests/gemspec:gemspec_test.bzl", "gemspec_test")
+load("//ruby:defs.bzl", "rb_gem")
 
-rb_gemspec(
-    name = "licensed_gem",
+gemspec_test(
+    name = "licensed_test",
     authors = ["Coinbase"],
     gem_name = "licensed_gem",
     licenses = ["MIT"],
@@ -13,20 +12,8 @@ rb_gemspec(
     ],
 )
 
-select_file(
-    name = "select_license_spec",
-    srcs = ":licensed_gem",
-    subpath = "licensed_gem.gemspec",
-)
-
-diff_test(
-    name = "licensed_gem_test",
-    file1 = ":select_license_spec",
-    file2 = ":expected/licensed_gem.gemspec",
-)
-
-rb_gemspec(
-    name = "example_gem",
+gemspec_test(
+    name = "example_test",
     authors = ["Coinbase"],
     gem_name = "example_gem",
     gem_runtime_dependencies = [
@@ -39,20 +26,8 @@ rb_gemspec(
     ],
 )
 
-select_file(
-    name = "select_example_spec",
-    srcs = ":example_gem",
-    subpath = "example_gem.gemspec",
-)
-
-diff_test(
-    name = "example_gem_test",
-    file1 = ":select_example_spec",
-    file2 = ":expected/example_gem.gemspec",
-)
-
-rb_gemspec(
-    name = "require_gem",
+gemspec_test(
+    name = "require_test",
     authors = ["Coinbase"],
     gem_name = "require_gem",
     require_paths = ["ruby/tests/gemspec/lib/foo"],
@@ -62,14 +37,14 @@ rb_gemspec(
     ],
 )
 
-select_file(
-    name = "select_require_spec",
-    srcs = ":require_gem",
-    subpath = "require_gem.gemspec",
-)
-
-diff_test(
-    name = "require_gem_test",
-    file1 = ":select_require_spec",
-    file2 = ":expected/require_gem.gemspec",
+gemspec_test(
+    name = "strip_path_test",
+    authors = ["Coinbase"],
+    gem_name = "strip_path_gem",
+    require_paths = ["lib"],
+    strip_paths = ["ruby/tests/gemspec"],
+    version = "0.1.0",
+    deps = [
+        "//ruby/tests/gemspec/lib:example_gem",
+    ],
 )

--- a/ruby/tests/gemspec/expected/strip_path_gem.gemspec
+++ b/ruby/tests/gemspec/expected/strip_path_gem.gemspec
@@ -1,0 +1,11 @@
+Gem::Specification.new do |s|
+  s.name                     = "strip_path_gem"
+  s.summary                  = "strip_path_gem"
+  s.authors                  = ["Coinbase"]
+  s.version                  = "0.1.0"
+  s.licenses                 = []
+  s.files                    = ["lib/foo/bar.rb", "lib/example_gem.rb"]
+  s.require_paths            = ["lib"]
+
+  
+end

--- a/ruby/tests/gemspec/gemspec_test.bzl
+++ b/ruby/tests/gemspec/gemspec_test.bzl
@@ -1,0 +1,30 @@
+load("@wspace_bazel_skylib//rules:diff_test.bzl", "diff_test")
+load("@wspace_bazel_skylib//rules:select_file.bzl", "select_file")
+load("//ruby:defs.bzl", "rb_gem", "rb_gemspec")
+
+def gemspec_test(name, **kwargs):
+    if not name.endswith("_test"):
+      fail("Gemspec test must end with '_test'")
+
+    base_name = name.replace("_test", "")
+    gem_name = "{}_gem".format(base_name)
+    select_name = "select_{}_spec".format(base_name)
+    gemspec_name = "{}.gemspec".format(gem_name)
+    expected_gemsepc = ":expected/{}".format(gemspec_name)
+
+    rb_gemspec(
+        name = gem_name,
+        **kwargs
+    )
+
+    select_file(
+        name = select_name,
+        srcs = gem_name,
+        subpath = gemspec_name,
+    )
+
+    diff_test(
+        name = name,
+        file1 = select_name,
+        file2 = expected_gemsepc,
+    )

--- a/ruby/tests/gemspec/gemspec_test.bzl
+++ b/ruby/tests/gemspec/gemspec_test.bzl
@@ -4,7 +4,7 @@ load("//ruby:defs.bzl", "rb_gem", "rb_gemspec")
 
 def gemspec_test(name, **kwargs):
     if not name.endswith("_test"):
-      fail("Gemspec test must end with '_test'")
+        fail("Gemspec test must end with '_test'")
 
     base_name = name.replace("_test", "")
     gem_name = "{}_gem".format(base_name)


### PR DESCRIPTION
Add ability to strip paths from the path that is added to the ruby gem.

Also clean up the gemspec tests to be a single macro.