### PR TITLE
Rename gems lib to prevent collision with gems dependency

### DIFF
--- a/ruby/private/bundle/create_bundle_build_file.rb
+++ b/ruby/private/bundle/create_bundle_build_file.rb
@@ -51,7 +51,7 @@ GEM_TEMPLATE
 
 ALL_GEMS = <<~ALL_GEMS
   rb_library(
-    name = "gems",
+    name = "all_gems",
     srcs = glob(
       {gems_lib_files},
     ),


### PR DESCRIPTION
The gems gem caused a name collision with the rb_library rule of the same name that contains all installed gems. Renaming to all_gems to avoid that collision - there is no all_gems gem on rubygems (there is allgems) so this won't currently collide. 