### PR TITLE
Add full_index option for faster bundle install

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ rb_bundle(
   gemfile = ":Gemfile",
   gemfile_lock = ":Gemfile.lock",
   bundler_version = "2.1.2",
+  full_index = True,
 )
 
 rb_bundle(
@@ -84,6 +85,7 @@ rb_bundle(
   gemfile = "//apps/shopping:Gemfile",
   gemfile_lock = "//apps/shopping:Gemfile.lock",
   bundler_version = "2.1.2",
+  full_index = True,
 )
 ```
 
@@ -474,6 +476,13 @@ rb_bundle(name, gemfile, gemfile_lock, bundler_version = "2.1.2")
         <code>String, optional</code>
           <p>The Version of Bundler to use. Defaults to 2.1.2.</p>
           <p>NOTE: This rule never updates the <code>Gemfile.lock</code>. It is your responsibility to generate/update <code>Gemfile.lock</code></p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>full_index</code></td>
+      <td>
+        <code>Bool, optional</code>
+          <p>Set to True to add the --full-index option to the bundle install. Can improve performance.</p>
       </td>
     </tr>
   </tbody>

--- a/ruby/private/bundle/bundle.bzl
+++ b/ruby/private/bundle/bundle.bzl
@@ -50,16 +50,17 @@ def install_bundler(runtime_ctx):
         fail("Error installing bundler: {} {}".format(result.stdout, result.stderr))
 
 def bundle_install(runtime_ctx):
-    result = run_bundler(
-        runtime_ctx,
-        [
-            "install",  #  bundle install
-            "--standalone",  # Makes a bundle that can work without depending on Rubygems or Bundler at runtime.
-            "--binstubs={}".format(BUNDLE_BIN_PATH),  # Creates a directory and place any executables from the gem there.
-            "--path={}".format(BUNDLE_PATH),  # The location to install the specified gems to.
-            "--jobs=10",  # run a few jobs to ensure no gem install is blocking another
-        ],
-    )
+    bundler_args = [
+        "install",  #  bundle install
+        "--standalone",  # Makes a bundle that can work without depending on Rubygems or Bundler at runtime.
+        "--binstubs={}".format(BUNDLE_BIN_PATH),  # Creates a directory and place any executables from the gem there.
+        "--path={}".format(BUNDLE_PATH),  # The location to install the specified gems to.
+        "--jobs=10",  # run a few jobs to ensure no gem install is blocking another
+    ]
+
+    if runtime_ctx.full_index:
+        bundler_args.append("--full-index")
+    result = run_bundler(runtime_ctx, bundler_args)
 
     if result.return_code:
         fail("bundle install failed: %s%s" % (result.stdout, result.stderr))
@@ -139,6 +140,10 @@ rb_bundle = repository_rule(
         ),
         "excludes": attr.string_list_dict(
             doc = "List of glob patterns per gem to be excluded from the library",
+        ),
+        "full_index": attr.bool(
+            default = False,
+            doc = "Use --full-index for bundle install",
         ),
         "_install_bundler": attr.label(
             default = "%s//ruby/private/bundle:%s" % (

--- a/ruby/private/bundle/bundle.bzl
+++ b/ruby/private/bundle/bundle.bzl
@@ -58,7 +58,7 @@ def bundle_install(runtime_ctx):
         "--jobs=10",  # run a few jobs to ensure no gem install is blocking another
     ]
 
-    if runtime_ctx.full_index:
+    if runtime_ctx.ctx.attr.full_index:
         bundler_args.append("--full-index")
     result = run_bundler(runtime_ctx, bundler_args)
 


### PR DESCRIPTION
Add full_index option to the rb_bundle rule that adds the --full-index option to the bundle install command. This option can improve bundle install performance - especially when installing lots of gems. Also add docs.